### PR TITLE
fix!: resolve critical bugs and remove unused inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,16 +91,14 @@ jobs:
 
 ## Inputs
 
-| Input                    | Description                                                                                                                                                 | Required | Default                       |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------- |
-| `github-token`           | Personal Access Token (PAT) with `repo` scope for GitHub API authentication. The default `GITHUB_TOKEN` has insufficient permissions for creating releases. | Yes      | -                             |
-| `tag-prefix`             | The prefix for version tags                                                                                                                                 | No       | `v`                           |
-| `release-branch`         | The branch to use for the release                                                                                                                           | No       | `main`                        |
-| `commit-regex`           | Custom regex pattern for commit messages                                                                                                                    | No       | Conventional Commits standard |
-| `dry-run`                | Simulate the process without creating releases                                                                                                              | No       | `false`                       |
-| `release-notes-template` | Template for release notes formatting                                                                                                                       | No       | Default template              |
-| `bump-rules`             | Custom commit type to version bump mapping                                                                                                                  | No       | Default rules                 |
-| `initial-version`        | The initial version to start from                                                                                                                           | No       | `1.0.0`                       |
+| Input                    | Description                                                                                                                                                 | Required | Default          |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------- |
+| `github-token`           | Personal Access Token (PAT) with `repo` scope for GitHub API authentication. The default `GITHUB_TOKEN` has insufficient permissions for creating releases. | Yes      | -                |
+| `tag-prefix`             | The prefix for version tags                                                                                                                                 | No       | `v`              |
+| `release-branch`         | The branch to use for the release                                                                                                                           | No       | `main`           |
+| `dry-run`                | Simulate the process without creating releases                                                                                                              | No       | `false`          |
+| `release-notes-template` | Template for release notes formatting                                                                                                                       | No       | Default template |
+| `initial-version`        | The initial version to start from                                                                                                                           | No       | `1.0.0`          |
 
 ## Outputs
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -143,5 +143,21 @@ describe('main', () => {
       expect(createOrUpdateRelease).not.toHaveBeenCalled()
       expect(setOutput).not.toHaveBeenCalled()
     })
+
+    it('should skip release when HEAD and tag point to same commit', async () => {
+      ;(getTags as Mock).mockResolvedValue([{ name: 'v1.0.0', version: '1.0.0' }])
+      ;(getLatestVersion as Mock).mockReturnValue({ name: 'v1.0.0', version: '1.0.0' })
+      // Mock both refs returning the same SHA
+      mockOctokit.rest.git.getRef.mockResolvedValue({
+        data: { object: { sha: 'same-sha-123' } }
+      })
+
+      await run()
+
+      // Should not process commits or create release
+      expect(getCommits).not.toHaveBeenCalled()
+      expect(createOrUpdateRelease).not.toHaveBeenCalled()
+      expect(setOutput).not.toHaveBeenCalled()
+    })
   })
 })

--- a/__tests__/templates.test.ts
+++ b/__tests__/templates.test.ts
@@ -393,5 +393,34 @@ describe('templates', () => {
       expect(notes).toContain('#### Api')
       expect(notes).toContain('remove deprecated endpoints')
     })
+
+    it('should use default template when template is only whitespace', () => {
+      const data = {
+        version: '1.0.0',
+        features: [{ type: 'feat', subject: 'new feature', message: 'feat: new feature', breaking: false }],
+        fixes: [],
+        breaking: []
+      }
+
+      const notes = compileReleaseNotes('   \n  \t  ', data)
+      // Should use default template, not empty template
+      expect(notes).toContain('### Features')
+      expect(notes).toContain('#### General')
+      expect(notes).toContain('new feature')
+    })
+
+    it('should handle empty string template by using default', () => {
+      const data = {
+        version: '1.0.0',
+        features: [{ type: 'feat', subject: 'new feature', message: 'feat: new feature', breaking: false }],
+        fixes: [],
+        breaking: []
+      }
+
+      const notes = compileReleaseNotes('', data)
+      // Empty string should trigger default template
+      expect(notes).toContain('### Features')
+      expect(notes).toContain('new feature')
+    })
   })
 })

--- a/__tests__/version.test.ts
+++ b/__tests__/version.test.ts
@@ -103,5 +103,25 @@ describe('version', () => {
       expect(getLatestVersion(tags, 'release-v')).toEqual({ name: 'release-v1.1.0', version: '1.1.0' })
       expect(getLatestVersion(tags, 'version-')).toEqual({ name: 'version-1.0.1', version: '1.0.1' })
     })
+
+    it('should handle equal versions correctly in sorting', () => {
+      const tags = [
+        { name: 'v1.0.0', version: '1.0.0' },
+        { name: 'v1.0.0', version: '1.0.0' },
+        { name: 'v1.1.0', version: '1.1.0' }
+      ]
+      // Should still return the latest version even with duplicates
+      expect(getLatestVersion(tags, 'v')).toEqual({ name: 'v1.1.0', version: '1.1.0' })
+    })
+
+    it('should handle many tags (>100 tags scenario)', () => {
+      // Create 150 tags to test pagination scenario
+      const tags = []
+      for (let i = 0; i < 150; i++) {
+        tags.push({ name: `v1.0.${String(i)}`, version: `1.0.${String(i)}` })
+      }
+      const latest = getLatestVersion(tags, 'v')
+      expect(latest).toEqual({ name: 'v1.0.149', version: '1.0.149' })
+    })
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,6 @@ inputs:
     description: The branch to use for the release
     required: false
     default: 'main'
-  commit-regex:
-    description: A custom regex pattern to identify and classify commit messages
-    required: false
   dry-run:
     description: Boolean flag to simulate the process without creating or updating a release
     required: false
@@ -63,9 +60,6 @@ inputs:
 
       {{/each}}
       {{/if}}
-  bump-rules:
-    description: Custom mapping of commit types to version bump levels (major, minor, patch)
-    required: false
   initial-version:
     description: The initial version to start from
     required: false
@@ -81,5 +75,5 @@ outputs:
     description: The ID of the created or updated draft release
 
 runs:
-  using: node20
+  using: node22
   main: dist/index.js

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,11 @@
+import { setFailed } from '@actions/core'
+
 import { run } from '@/main.js'
 
-void run()
+run().catch((error: unknown) => {
+  if (error instanceof Error) {
+    setFailed(error.message)
+  } else {
+    setFailed(`An unexpected error occurred: ${String(error)}`)
+  }
+})

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -89,7 +89,9 @@ export const compileReleaseNotes = (template: string, data: ReleaseNotesData): s
     - Breaking changes: ${String(data.breaking.length)}`)
 
   try {
-    const compiledTemplate = Handlebars.compile(template || DEFAULT_TEMPLATE)
+    // Use default template if no template provided or if template is empty/whitespace
+    const templateToUse = template && template.trim() !== '' ? template : DEFAULT_TEMPLATE
+    const compiledTemplate = Handlebars.compile(templateToUse)
     const releaseNotes = compiledTemplate(data)
 
     info('Release notes compiled successfully')

--- a/src/version/index.ts
+++ b/src/version/index.ts
@@ -1,5 +1,5 @@
 import { debug, info, warning } from '@actions/core'
-import { gt, valid } from 'semver'
+import { rcompare, valid } from 'semver'
 
 export type VersionType = 'major' | 'minor' | 'patch'
 
@@ -47,7 +47,8 @@ export const getLatestVersion = (tags: Tag[], tagPrefix: string): Tag | undefine
       // Remove pre-release and build metadata for comparison
       const aBase = a.version.split('-')[0].split('+')[0]
       const bBase = b.version.split('-')[0].split('+')[0]
-      return gt(aBase, bBase) ? -1 : 1
+      // Use rcompare for descending order (latest version first)
+      return rcompare(aBase, bBase)
     })
 
   if (semverTags.length > 0) {


### PR DESCRIPTION
- Add proper error handling with setFailed() for promise rejections
- Fix version sorting bug using rcompare instead of broken gt() logic
- Implement tag pagination to support repos with >100 tags
- Add validation to skip processing when HEAD equals tag SHA
- Fix DEFAULT_TEMPLATE fallback for empty/whitespace templates
- Update node runtime from node20 to node22
- Remove unused commit-regex and bump-rules inputs
- Add unit tests for edge cases (equal versions, >100 tags, same SHA)

BREAKING CHANGE: Removed commit-regex and bump-rules inputs from action.yml. These inputs were documented but never implemented. Users referencing these inputs should remove them from their workflow configurations. Node runtime requirement updated to node22.