### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,52 @@
+name: Bug Report
+description: Report a bug with SAVR
+labels: ['bug']
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What's wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: How to trigger the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What should happen instead?
+    validations:
+      required: true
+  - type: input
+    id: action-version
+    attributes:
+      label: Action Version
+      description: Version of SAVR being used.
+      placeholder: e.g. 1.2.0
+    validations:
+      required: true
+  - type: dropdown
+    id: runner-environment
+    attributes:
+      label: Runner Environment
+      options:
+        - ubuntu-latest
+        - macos-latest
+        - windows-latest
+        - other
+  - type: textarea
+    id: workflow-config
+    attributes:
+      label: Relevant workflow config
+      description: The workflow YAML or config snippet, if applicable.
+      render: yaml
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,26 @@
+name: Feature Request
+description: Suggest a new feature for SAVR
+labels: ['enhancement']
+body:
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem statement
+      description: What problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: How should it work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,40 @@
+name: Improvement
+description: Suggest a code quality, refactoring, performance, or technical debt improvement
+labels: ['improvement']
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which module is affected?
+      options:
+        - commits
+        - version
+        - github
+        - templates
+        - utils
+        - config
+        - other
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What should be improved and why?
+    validations:
+      required: true
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current behavior
+      description: How does it work now?
+  - type: textarea
+    id: suggested-change
+    attributes:
+      label: Suggested change
+      description: Concrete proposal for the improvement.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context


### PR DESCRIPTION
## Summary

- Add YAML-based issue form templates for bug reports, improvements, and feature requests
- Add config to keep blank issues enabled
- Templates are structured for both human and AI agent use

## Templates

| Template | Labels | Purpose |
|----------|--------|---------|
| `bug-report.yml` | `bug` | Bug reports with reproduction steps, version, and environment |
| `improvement.yml` | `improvement` | Code quality, refactoring, and technical debt suggestions |
| `feature-request.yml` | `enhancement` | New feature proposals |
| `config.yml` | — | Keeps blank issues enabled |

## Test plan

- [ ] Open the "New Issue" page on GitHub and verify all three templates appear
- [ ] Confirm each form renders with the correct fields and required validations
- [ ] Verify blank issues are still allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)