### PR TITLE
fix(ci): remove invalid `labels` permission from labels workflow

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   issues: write
-  labels: write
 
 jobs:
   workflows:


### PR DESCRIPTION
## Summary
- Removes invalid `labels: write` permission from the labels sync workflow
- This permission scope doesn't exist in GitHub Actions, causing the workflow to fail on every trigger
- Label management is already covered by the existing `issues: write` permission

## Test plan
- [ ] Verify the labels sync workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)