### PR TITLE
fix: set target_commitish for release-branch tags

### DIFF
--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -230,5 +230,54 @@ describe('github', () => {
         release_id: 1
       })
     })
+
+    it('should set target_commitish when provided for release creation', async () => {
+      mockOctokit.rest.repos.listReleases.mockResolvedValue({ data: [] })
+      mockOctokit.rest.repos.createRelease.mockResolvedValue({
+        data: {
+          id: 1,
+          html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.0',
+          tag_name: 'v1.0.0'
+        }
+      })
+
+      await createOrUpdateRelease(githubContext, 'v1.0.0', '1.0.0', 'Release notes', 'release-branch-sha')
+
+      expect(mockOctokit.rest.repos.createRelease).toHaveBeenCalledWith({
+        owner: 'test-owner',
+        repo: 'test-repo',
+        tag_name: 'v1.0.0',
+        name: '1.0.0',
+        body: 'Release notes',
+        draft: true,
+        target_commitish: 'release-branch-sha'
+      })
+    })
+
+    it('should set target_commitish when provided for release update', async () => {
+      mockOctokit.rest.repos.listReleases.mockResolvedValue({
+        data: [
+          {
+            id: 1,
+            tag_name: 'v1.0.0',
+            draft: true,
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.0'
+          }
+        ]
+      })
+      mockOctokit.rest.repos.updateRelease.mockResolvedValue({
+        data: {
+          id: 1,
+          html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.0',
+          tag_name: 'v1.0.0'
+        }
+      })
+
+      await createOrUpdateRelease(githubContext, 'v1.0.0', '1.0.0', 'Updated release notes', 'release-branch-sha')
+
+      expect(mockOctokit.rest.repos.updateRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ target_commitish: 'release-branch-sha', release_id: 1 })
+      )
+    })
   })
 })

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -120,7 +120,8 @@ describe('main', () => {
         { owner: 'owner', repo: 'repo', octokit: mockOctokit },
         'v1.1.0',
         '1.1.0',
-        'Release notes'
+        'Release notes',
+        'head-sha'
       )
       expect(setOutput).toHaveBeenCalledWith('release-url', 'https://github.com/owner/repo/releases/tag/v1.1.0')
       expect(setOutput).toHaveBeenCalledWith('release-id', '123')
@@ -208,7 +209,13 @@ describe('main', () => {
         'head-sha',
         'tag-commit-sha'
       )
-      expect(createOrUpdateRelease).toHaveBeenCalled()
+      expect(createOrUpdateRelease).toHaveBeenCalledWith(
+        { owner: 'owner', repo: 'repo', octokit: mockOctokit },
+        'v1.1.0',
+        '1.1.0',
+        'Release notes',
+        'head-sha'
+      )
     })
 
     it('should skip release when HEAD matches dereferenced annotated tag commit', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -47290,7 +47290,7 @@ const deleteRelease = async (context, releaseId) => {
         throw err;
     }
 };
-const createOrUpdateRelease = async (context, tagName, releaseName, releaseNotes, draft = true) => {
+const createOrUpdateRelease = async (context, tagName, releaseName, releaseNotes, targetCommitish, draft = true) => {
     core_debug(`Checking for existing draft release with tag ${tagName}`);
     try {
         const { data: releases } = await context.octokit.rest.repos.listReleases({
@@ -47304,7 +47304,8 @@ const createOrUpdateRelease = async (context, tagName, releaseName, releaseNotes
             tag_name: tagName,
             name: releaseName,
             body: releaseNotes,
-            draft
+            draft,
+            ...(targetCommitish ? { target_commitish: targetCommitish } : {})
         };
         let release;
         if (existingDraft) {
@@ -47587,7 +47588,7 @@ const run = async () => {
     }
     const tagName = `${tagPrefix}${newVersion}`;
     const releaseName = newVersion;
-    const release = await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes);
+    const release = await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes, headData.object.sha);
     setOutput('release-url', release.url);
     setOutput('release-id', release.id.toString());
     setOutput('version', release.tagName);

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -125,6 +125,7 @@ export const createOrUpdateRelease = async (
   tagName: string,
   releaseName: string,
   releaseNotes: string,
+  targetCommitish?: string,
   draft = true
 ): Promise<GitHubRelease> => {
   debug(`Checking for existing draft release with tag ${tagName}`)
@@ -142,7 +143,8 @@ export const createOrUpdateRelease = async (
       tag_name: tagName,
       name: releaseName,
       body: releaseNotes,
-      draft
+      draft,
+      ...(targetCommitish ? { target_commitish: targetCommitish } : {})
     }
 
     let release

--- a/src/main.ts
+++ b/src/main.ts
@@ -132,7 +132,7 @@ export const run = async (): Promise<void> => {
   const tagName = `${tagPrefix}${newVersion}`
   const releaseName = newVersion
 
-  const release = await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes)
+  const release = await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes, headData.object.sha)
 
   setOutput('release-url', release.url)
   setOutput('release-id', release.id.toString())


### PR DESCRIPTION
## Summary
- pass release branch HEAD SHA as `target_commitish` when creating/updating releases
- ensure tags are created against the configured `release-branch` instead of default branch
- add regression tests for `target_commitish` in GitHub API calls and main flow

## Validation
- pnpm vitest run __tests__/main.test.ts __tests__/github.test.ts
- pnpm test
- pnpm build

Closes #110
