### PR TITLE
fix(github): paginate release listing in createOrUpdateRelease (#126)

### DIFF
--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -279,5 +279,58 @@ describe('github', () => {
         expect.objectContaining({ target_commitish: 'release-branch-sha', release_id: 1 })
       )
     })
+
+    it('should paginate releases when finding existing drafts', async () => {
+      const pageOneReleases = Array.from({ length: 100 }, (_, index) => {
+        const releaseNumber = String(index + 1)
+
+        return {
+          id: index + 1,
+          tag_name: `v0.${releaseNumber}.0`,
+          draft: false,
+          html_url: `https://github.com/test-owner/test-repo/releases/tag/v0.${releaseNumber}.0`
+        }
+      })
+
+      mockOctokit.rest.repos.listReleases.mockResolvedValueOnce({ data: pageOneReleases }).mockResolvedValueOnce({
+        data: [
+          {
+            id: 101,
+            tag_name: 'v1.9.9',
+            draft: true,
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.9.9'
+          }
+        ]
+      })
+      mockOctokit.rest.repos.createRelease.mockResolvedValue({
+        data: {
+          id: 102,
+          html_url: 'https://github.com/test-owner/test-repo/releases/tag/v2.0.0',
+          tag_name: 'v2.0.0'
+        }
+      })
+      mockOctokit.rest.repos.deleteRelease.mockResolvedValue({ data: {} })
+
+      await createOrUpdateRelease(githubContext, 'v2.0.0', '2.0.0', 'Release notes')
+
+      expect(mockOctokit.rest.repos.listReleases).toHaveBeenCalledTimes(2)
+      expect(mockOctokit.rest.repos.listReleases).toHaveBeenNthCalledWith(1, {
+        owner: 'test-owner',
+        repo: 'test-repo',
+        per_page: 100,
+        page: 1
+      })
+      expect(mockOctokit.rest.repos.listReleases).toHaveBeenNthCalledWith(2, {
+        owner: 'test-owner',
+        repo: 'test-repo',
+        per_page: 100,
+        page: 2
+      })
+      expect(mockOctokit.rest.repos.deleteRelease).toHaveBeenCalledWith({
+        owner: 'test-owner',
+        repo: 'test-repo',
+        release_id: 101
+      })
+    })
   })
 })

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -120,6 +120,33 @@ export const deleteRelease = async (context: GitHubContext, releaseId: number): 
   }
 }
 
+const listAllReleases = async (
+  context: GitHubContext
+): Promise<{ id: number; tag_name: string; draft: boolean; html_url: string }[]> => {
+  const allReleases: { id: number; tag_name: string; draft: boolean; html_url: string }[] = []
+  let page = 1
+  let hasMore = true
+
+  while (hasMore) {
+    debug(`Fetching releases page ${String(page)}`)
+    const { data: pageReleases } = await context.octokit.rest.repos.listReleases({
+      owner: context.owner,
+      repo: context.repo,
+      per_page: 100,
+      page
+    })
+
+    allReleases.push(...pageReleases)
+
+    hasMore = pageReleases.length === 100
+    if (hasMore) {
+      page++
+    }
+  }
+
+  return allReleases
+}
+
 export const createOrUpdateRelease = async (
   context: GitHubContext,
   tagName: string,
@@ -131,10 +158,7 @@ export const createOrUpdateRelease = async (
   debug(`Checking for existing draft release with tag ${tagName}`)
 
   try {
-    const { data: releases } = await context.octokit.rest.repos.listReleases({
-      owner: context.owner,
-      repo: context.repo
-    })
+    const releases = await listAllReleases(context)
     const existingDraft = releases.find(({ draft, tag_name }) => draft && tag_name === tagName)
 
     const releaseParams = {


### PR DESCRIPTION
## Summary
- paginate release fetching in createOrUpdateRelease using per_page=100 and page traversal
- ensure old draft cleanup sees releases beyond first page
- add regression test for paginated release discovery

## Testing
- pnpm test -- __tests__/github.test.ts

Closes #126