### PR TITLE
fix(github): handle concurrent draft deletion 404s (#127)

### DIFF
--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -332,5 +332,38 @@ describe('github', () => {
         release_id: 101
       })
     })
+
+    it('should ignore 404 errors when deleting old drafts concurrently', async () => {
+      mockOctokit.rest.repos.listReleases.mockResolvedValue({
+        data: [
+          {
+            id: 1,
+            tag_name: 'v1.0.1',
+            draft: true,
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.1'
+          }
+        ]
+      })
+      mockOctokit.rest.repos.createRelease.mockResolvedValue({
+        data: {
+          id: 2,
+          html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.1.0',
+          tag_name: 'v1.1.0'
+        }
+      })
+      const notFoundError = Object.assign(new Error('Not Found'), { status: 404 })
+      mockOctokit.rest.repos.deleteRelease.mockRejectedValue(notFoundError)
+
+      await expect(createOrUpdateRelease(githubContext, 'v1.1.0', '1.1.0', 'Release notes')).resolves.toEqual({
+        id: 2,
+        url: 'https://github.com/test-owner/test-repo/releases/tag/v1.1.0',
+        tagName: 'v1.1.0'
+      })
+      expect(mockOctokit.rest.repos.deleteRelease).toHaveBeenCalledWith({
+        owner: 'test-owner',
+        repo: 'test-repo',
+        release_id: 1
+      })
+    })
   })
 })

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -1,4 +1,4 @@
-import { debug, error, info } from '@actions/core'
+import { debug, error, info, warning } from '@actions/core'
 import { getOctokit } from '@actions/github'
 
 import { Commit, parseCommit } from '../commits/index.js'
@@ -192,7 +192,21 @@ export const createOrUpdateRelease = async (
       info(`Found ${String(otherDrafts.length)} old draft release(s) to delete`)
       for (const oldDraft of otherDrafts) {
         info(`Deleting old draft release: ${oldDraft.tag_name} (ID: ${String(oldDraft.id)})`)
-        await deleteRelease(context, oldDraft.id)
+
+        try {
+          await deleteRelease(context, oldDraft.id)
+        } catch (deletionError) {
+          const deletionStatus = (deletionError as { status?: number }).status
+
+          if (deletionStatus === 404) {
+            warning(
+              `Old draft release ${oldDraft.tag_name} (ID: ${String(oldDraft.id)}) was already deleted by another workflow run`
+            )
+            continue
+          }
+
+          throw deletionError
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- catch draft-deletion errors during cleanup
- ignore 404 responses that occur when another concurrent workflow already deleted the draft
- keep failing behavior for non-404 errors
- add regression test for concurrent deletion race

## Testing
- pnpm test -- __tests__/github.test.ts

Closes #127