### PR TITLE
fix(commits): support BREAKING-CHANGE footer token (#129)

### DIFF
--- a/__tests__/commits.test.ts
+++ b/__tests__/commits.test.ts
@@ -87,6 +87,16 @@ describe('commits', () => {
       })
     })
 
+    it('should handle commit messages with hyphenated breaking change footer', () => {
+      const commit = parseCommit('feat: add new feature\n\nBREAKING-CHANGE: This is a breaking change')
+      expect(commit).toEqual({
+        type: 'feat',
+        subject: 'add new feature',
+        message: 'feat: add new feature',
+        breaking: true
+      })
+    })
+
     it('should ignore conventional commit patterns in body text', () => {
       const commit = parseCommit(
         'feat: support multiple languages\n\n* feat: enhance authentication flow\n* fix: update locale type'

--- a/src/commits/index.ts
+++ b/src/commits/index.ts
@@ -50,7 +50,7 @@ export const parseCommit = (message: string): Commit => {
   }
 
   const [, type, scope, isBreaking, subject] = match
-  const breaking = isBreaking === '!' || message.includes('BREAKING CHANGE:')
+  const breaking = isBreaking === '!' || /BREAKING[ -]CHANGE:/.test(message)
 
   debug(`Parsed commit - Type: ${type}, Scope: ${scope || 'none'}, Breaking: ${String(breaking)}`)
   return {


### PR DESCRIPTION
## Summary
- expand breaking-change footer detection to match both BREAKING CHANGE: and BREAKING-CHANGE:
- add test coverage for hyphenated footer form

## Testing
- pnpm test -- __tests__/commits.test.ts

Closes #129