### PR TITLE
feat(github): only delete SAVR-managed draft releases

### DIFF
--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createOrUpdateRelease, deleteRelease, type GitHubContext } from '../src/github/index.js'
+import { createOrUpdateRelease, deleteRelease, type GitHubContext, SAVR_MARKER } from '../src/github/index.js'
 
 describe('github', () => {
   const mockOctokit = {
@@ -56,7 +56,7 @@ describe('github', () => {
         repo: 'test-repo',
         tag_name: 'v1.0.0',
         name: '1.0.0',
-        body: 'Release notes',
+        body: `Release notes\n${SAVR_MARKER}`,
         draft: true
       })
       expect(result).toEqual({
@@ -73,7 +73,8 @@ describe('github', () => {
             id: 1,
             tag_name: 'v1.0.0',
             draft: true,
-            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.0'
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.0',
+            body: `Release notes\n${SAVR_MARKER}`
           }
         ]
       })
@@ -92,7 +93,7 @@ describe('github', () => {
         repo: 'test-repo',
         tag_name: 'v1.0.0',
         name: '1.0.0',
-        body: 'Updated release notes',
+        body: `Updated release notes\n${SAVR_MARKER}`,
         draft: true,
         release_id: 1
       })
@@ -107,13 +108,15 @@ describe('github', () => {
             id: 1,
             tag_name: 'v1.0.1',
             draft: true,
-            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.1'
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.1',
+            body: `Release notes\n${SAVR_MARKER}`
           },
           {
             id: 2,
             tag_name: 'v1.0.0',
             draft: false,
-            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.0'
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.0',
+            body: 'Release notes'
           }
         ]
       })
@@ -133,7 +136,7 @@ describe('github', () => {
         repo: 'test-repo',
         tag_name: 'v1.1.0',
         name: '1.1.0',
-        body: 'Release notes',
+        body: `Release notes\n${SAVR_MARKER}`,
         draft: true
       })
       // Should delete the old draft (v1.0.1) but not the published release (v1.0.0)
@@ -153,19 +156,22 @@ describe('github', () => {
             id: 1,
             tag_name: 'v1.0.1',
             draft: true,
-            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.1'
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.1',
+            body: `Release notes\n${SAVR_MARKER}`
           },
           {
             id: 2,
             tag_name: 'v1.0.2',
             draft: true,
-            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.2'
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.2',
+            body: `Release notes\n${SAVR_MARKER}`
           },
           {
             id: 3,
             tag_name: 'v1.0.0',
             draft: false,
-            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.0'
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.0',
+            body: 'Release notes'
           }
         ]
       })
@@ -201,13 +207,15 @@ describe('github', () => {
             id: 1,
             tag_name: 'v1.0.1',
             draft: true,
-            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.1'
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.1',
+            body: `Release notes\n${SAVR_MARKER}`
           },
           {
             id: 2,
             tag_name: 'v1.1.0',
             draft: true,
-            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.1.0'
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.1.0',
+            body: `Updated release notes\n${SAVR_MARKER}`
           }
         ]
       })
@@ -248,7 +256,7 @@ describe('github', () => {
         repo: 'test-repo',
         tag_name: 'v1.0.0',
         name: '1.0.0',
-        body: 'Release notes',
+        body: `Release notes\n${SAVR_MARKER}`,
         draft: true,
         target_commitish: 'release-branch-sha'
       })
@@ -261,7 +269,8 @@ describe('github', () => {
             id: 1,
             tag_name: 'v1.0.0',
             draft: true,
-            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.0'
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.0',
+            body: `Release notes\n${SAVR_MARKER}`
           }
         ]
       })
@@ -298,7 +307,8 @@ describe('github', () => {
             id: 101,
             tag_name: 'v1.9.9',
             draft: true,
-            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.9.9'
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.9.9',
+            body: `Release notes\n${SAVR_MARKER}`
           }
         ]
       })
@@ -333,6 +343,45 @@ describe('github', () => {
       })
     })
 
+    it('should not delete non-SAVR draft releases during cleanup', async () => {
+      mockOctokit.rest.repos.listReleases.mockResolvedValue({
+        data: [
+          {
+            id: 1,
+            tag_name: 'v1.0.1',
+            draft: true,
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.1',
+            body: 'Manually created draft release'
+          },
+          {
+            id: 2,
+            tag_name: 'v0.9.0',
+            draft: true,
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v0.9.0',
+            body: `Release notes\n${SAVR_MARKER}`
+          }
+        ]
+      })
+      mockOctokit.rest.repos.createRelease.mockResolvedValue({
+        data: {
+          id: 3,
+          html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.1.0',
+          tag_name: 'v1.1.0'
+        }
+      })
+      mockOctokit.rest.repos.deleteRelease.mockResolvedValue({ data: {} })
+
+      await createOrUpdateRelease(githubContext, 'v1.1.0', '1.1.0', 'Release notes')
+
+      // Should only delete the SAVR-managed draft (v0.9.0), not the manually created one (v1.0.1)
+      expect(mockOctokit.rest.repos.deleteRelease).toHaveBeenCalledTimes(1)
+      expect(mockOctokit.rest.repos.deleteRelease).toHaveBeenCalledWith({
+        owner: 'test-owner',
+        repo: 'test-repo',
+        release_id: 2
+      })
+    })
+
     it('should ignore 404 errors when deleting old drafts concurrently', async () => {
       mockOctokit.rest.repos.listReleases.mockResolvedValue({
         data: [
@@ -340,7 +389,8 @@ describe('github', () => {
             id: 1,
             tag_name: 'v1.0.1',
             draft: true,
-            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.1'
+            html_url: 'https://github.com/test-owner/test-repo/releases/tag/v1.0.1',
+            body: `Release notes\n${SAVR_MARKER}`
           }
         ]
       })

--- a/dist/index.js
+++ b/dist/index.js
@@ -47197,6 +47197,7 @@ const determineVersionBump = (categorizedCommits) => {
 ;// CONCATENATED MODULE: ./src/github/index.ts
 
 
+const SAVR_MARKER = '<!-- savr-managed-release -->';
 const getTags = async (context) => {
     core_debug(`Fetching tags for repository ${context.owner}/${context.repo}`);
     const allTags = [];
@@ -47320,7 +47321,7 @@ const createOrUpdateRelease = async (context, tagName, releaseName, releaseNotes
             repo: context.repo,
             tag_name: tagName,
             name: releaseName,
-            body: releaseNotes,
+            body: `${releaseNotes}\n${SAVR_MARKER}`,
             draft,
             ...(targetCommitish ? { target_commitish: targetCommitish } : {})
         };
@@ -47339,7 +47340,7 @@ const createOrUpdateRelease = async (context, tagName, releaseName, releaseNotes
             release = data;
         }
         // Clean up other draft releases (keep only the current one)
-        const otherDrafts = releases.filter(({ draft, tag_name, id }) => draft && tag_name !== tagName && id !== release.id);
+        const otherDrafts = releases.filter(({ draft, tag_name, id, body }) => draft && tag_name !== tagName && id !== release.id && body?.includes(SAVR_MARKER));
         if (otherDrafts.length > 0) {
             info(`Found ${String(otherDrafts.length)} old draft release(s) to delete`);
             for (const oldDraft of otherDrafts) {

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -4,6 +4,8 @@ import { getOctokit } from '@actions/github'
 import { Commit, parseCommit } from '../commits/index.js'
 import { Tag } from '../version/index.js'
 
+export const SAVR_MARKER = '<!-- savr-managed-release -->'
+
 export interface GitHubContext {
   owner: string
   repo: string
@@ -122,8 +124,8 @@ export const deleteRelease = async (context: GitHubContext, releaseId: number): 
 
 const listAllReleases = async (
   context: GitHubContext
-): Promise<{ id: number; tag_name: string; draft: boolean; html_url: string }[]> => {
-  const allReleases: { id: number; tag_name: string; draft: boolean; html_url: string }[] = []
+): Promise<{ id: number; tag_name: string; draft: boolean; html_url: string; body?: string | null }[]> => {
+  const allReleases: { id: number; tag_name: string; draft: boolean; html_url: string; body?: string | null }[] = []
   let page = 1
   let hasMore = true
 
@@ -166,7 +168,7 @@ export const createOrUpdateRelease = async (
       repo: context.repo,
       tag_name: tagName,
       name: releaseName,
-      body: releaseNotes,
+      body: `${releaseNotes}\n${SAVR_MARKER}`,
       draft,
       ...(targetCommitish ? { target_commitish: targetCommitish } : {})
     }
@@ -186,7 +188,10 @@ export const createOrUpdateRelease = async (
     }
 
     // Clean up other draft releases (keep only the current one)
-    const otherDrafts = releases.filter(({ draft, tag_name, id }) => draft && tag_name !== tagName && id !== release.id)
+    const otherDrafts = releases.filter(
+      ({ draft, tag_name, id, body }) =>
+        draft && tag_name !== tagName && id !== release.id && body?.includes(SAVR_MARKER)
+    )
 
     if (otherDrafts.length > 0) {
       info(`Found ${String(otherDrafts.length)} old draft release(s) to delete`)


### PR DESCRIPTION
## Summary
- Adds a hidden HTML comment marker (`<!-- savr-managed-release -->`) to all SAVR-created release bodies
- Filters draft release cleanup to only delete drafts containing the marker
- Prevents accidental deletion of manually-created or third-party draft releases

Closes #96

## Test plan
- [x] Existing draft deletion tests updated with marker in body
- [x] New test: non-SAVR drafts are preserved during cleanup
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)