### PR TITLE
fix(version): replace manual increment with semver.inc

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -243,5 +243,26 @@ describe('main', () => {
       expect(createOrUpdateRelease).not.toHaveBeenCalled()
       expect(setOutput).not.toHaveBeenCalled()
     })
+
+    it('should throw for invalid initial-version', async () => {
+      ;(getInput as Mock).mockImplementation((name: string) => {
+        switch (name) {
+          case 'github-token':
+            return 'token'
+          case 'tag-prefix':
+            return 'v'
+          case 'release-branch':
+            return 'main'
+          case 'release-notes-template':
+            return ''
+          case 'initial-version':
+            return 'not-valid'
+          default:
+            return ''
+        }
+      })
+
+      await expect(run()).rejects.toThrow('Invalid initial version')
+    })
   })
 })

--- a/__tests__/version.test.ts
+++ b/__tests__/version.test.ts
@@ -20,21 +20,25 @@ describe('version', () => {
     })
 
     it('should handle pre-release versions', () => {
-      expect(incrementVersion('1.0.0-alpha.1', 'major')).toBe('2.0.0')
-      expect(incrementVersion('1.0.0-beta.1', 'minor')).toBe('1.1.0')
-      expect(incrementVersion('1.0.0-rc.1', 'patch')).toBe('1.0.1')
+      expect(incrementVersion('1.0.0-alpha.1', 'major')).toBe('1.0.0')
+      expect(incrementVersion('1.0.0-beta.1', 'minor')).toBe('1.0.0')
+      expect(incrementVersion('1.0.0-rc.1', 'patch')).toBe('1.0.0')
     })
 
     it('should handle build metadata', () => {
-      expect(incrementVersion('1.0.0+20130313144700', 'major')).toBe('2.0.0+20130313144700')
-      expect(incrementVersion('1.0.0+exp.sha.5114f85', 'minor')).toBe('1.1.0+exp.sha.5114f85')
-      expect(incrementVersion('1.0.0+20130313144700', 'patch')).toBe('1.0.1+20130313144700')
+      expect(incrementVersion('1.0.0+20130313144700', 'major')).toBe('2.0.0')
+      expect(incrementVersion('1.0.0+exp.sha.5114f85', 'minor')).toBe('1.1.0')
+      expect(incrementVersion('1.0.0+20130313144700', 'patch')).toBe('1.0.1')
     })
 
     it('should handle versions with both pre-release and build metadata', () => {
-      expect(incrementVersion('1.0.0-alpha.1+20130313144700', 'major')).toBe('2.0.0+20130313144700')
-      expect(incrementVersion('1.0.0-beta.1+exp.sha.5114f85', 'minor')).toBe('1.1.0+exp.sha.5114f85')
-      expect(incrementVersion('1.0.0-rc.1+20130313144700', 'patch')).toBe('1.0.1+20130313144700')
+      expect(incrementVersion('1.0.0-alpha.1+20130313144700', 'major')).toBe('1.0.0')
+      expect(incrementVersion('1.0.0-beta.1+exp.sha.5114f85', 'minor')).toBe('1.0.0')
+      expect(incrementVersion('1.0.0-rc.1+20130313144700', 'patch')).toBe('1.0.0')
+    })
+
+    it('should throw for invalid version string', () => {
+      expect(() => incrementVersion('not-a-version', 'patch')).toThrow('Failed to increment version')
     })
   })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -47086,6 +47086,8 @@ function getOctokit(token, options, ...additionalPlugins) {
     return new GitHubWithPlugins(getOctokitOptions(token, options));
 }
 //# sourceMappingURL=github.js.map
+// EXTERNAL MODULE: ./node_modules/.pnpm/semver@7.7.4/node_modules/semver/index.js
+var semver = __nccwpck_require__(9419);
 ;// CONCATENATED MODULE: ./src/utils/index.ts
 /**
  * Utility functions for safe logging and string handling
@@ -47475,29 +47477,17 @@ const compileReleaseNotes = (template, data) => {
     }
 };
 
-// EXTERNAL MODULE: ./node_modules/.pnpm/semver@7.7.4/node_modules/semver/index.js
-var semver = __nccwpck_require__(9419);
 ;// CONCATENATED MODULE: ./src/version/index.ts
 
 
 const incrementVersion = (version, type) => {
     core_debug(`Incrementing version ${version} by ${type}`);
-    // Split version into base version and metadata
-    const [baseVersion, ...metadata] = version.split('+');
-    const [versionWithoutPreRelease] = baseVersion.split('-');
-    // Parse the base version numbers
-    const [major, minor, patch] = versionWithoutPreRelease.split('.').map(Number);
-    // Calculate new version numbers based on type
-    const increments = {
-        major: [major + 1, 0, 0],
-        minor: [major, minor + 1, 0],
-        patch: [major, minor, patch + 1]
-    };
-    // Construct new version
-    const newBaseVersion = increments[type].join('.');
-    const newVersion = metadata.length > 0 ? `${newBaseVersion}+${metadata.join('+')}` : newBaseVersion;
-    info(`New version calculated: ${newVersion}`);
-    return newVersion;
+    const result = (0,semver.inc)(version, type);
+    if (result == null) {
+        throw new Error(`Failed to increment version "${version}" by "${type}"`);
+    }
+    info(`New version calculated: ${result}`);
+    return result;
 };
 const getLatestVersion = (tags, tagPrefix) => {
     core_debug(`Finding latest version from ${String(tags.length)} tags with prefix "${tagPrefix}"`);
@@ -47531,6 +47521,7 @@ const getLatestVersion = (tags, tagPrefix) => {
 
 
 
+
 const processCommits = async (githubContext, head, sinceTag) => {
     const commits = await getCommits(githubContext, head, sinceTag);
     info('Retrieved commits:');
@@ -47552,6 +47543,9 @@ const run = async () => {
     const releaseNotesTemplate = getInput('release-notes-template');
     const dryRun = getBooleanInput('dry-run');
     const initialVersion = getInput('initial-version');
+    if (!(0,semver.valid)(initialVersion)) {
+        throw new Error(`Invalid initial version: "${initialVersion}". Must be a valid semver string (e.g., 1.0.0)`);
+    }
     const octokit = getOctokit(token);
     const { owner, repo } = github_context.repo;
     if (!owner || !repo) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { getBooleanInput, getInput, info, setOutput } from '@actions/core'
 import { context, getOctokit } from '@actions/github'
+import { valid } from 'semver'
 
 import { categorizeCommits, determineVersionBump } from './commits/index.js'
 import { createOrUpdateRelease, getCommits, getTags, type GitHubContext } from './github/index.js'
@@ -31,6 +32,9 @@ export const run = async (): Promise<void> => {
   const releaseNotesTemplate = getInput('release-notes-template')
   const dryRun = getBooleanInput('dry-run')
   const initialVersion = getInput('initial-version')
+  if (!valid(initialVersion)) {
+    throw new Error(`Invalid initial version: "${initialVersion}". Must be a valid semver string (e.g., 1.0.0)`)
+  }
 
   const octokit = getOctokit(token)
   const { owner, repo } = context.repo

--- a/src/version/index.ts
+++ b/src/version/index.ts
@@ -1,5 +1,5 @@
 import { debug, info, warning } from '@actions/core'
-import { rcompare, valid } from 'semver'
+import { inc, rcompare, valid } from 'semver'
 
 export type VersionType = 'major' | 'minor' | 'patch'
 
@@ -10,27 +10,12 @@ export interface Tag {
 
 export const incrementVersion = (version: string, type: VersionType): string => {
   debug(`Incrementing version ${version} by ${type}`)
-
-  // Split version into base version and metadata
-  const [baseVersion, ...metadata] = version.split('+')
-  const [versionWithoutPreRelease] = baseVersion.split('-')
-
-  // Parse the base version numbers
-  const [major, minor, patch] = versionWithoutPreRelease.split('.').map(Number)
-
-  // Calculate new version numbers based on type
-  const increments = {
-    major: [major + 1, 0, 0],
-    minor: [major, minor + 1, 0],
-    patch: [major, minor, patch + 1]
+  const result = inc(version, type)
+  if (result == null) {
+    throw new Error(`Failed to increment version "${version}" by "${type}"`)
   }
-
-  // Construct new version
-  const newBaseVersion = increments[type].join('.')
-  const newVersion = metadata.length > 0 ? `${newBaseVersion}+${metadata.join('+')}` : newBaseVersion
-
-  info(`New version calculated: ${newVersion}`)
-  return newVersion
+  info(`New version calculated: ${result}`)
+  return result
 }
 
 export const getLatestVersion = (tags: Tag[], tagPrefix: string): Tag | undefined => {


### PR DESCRIPTION
## Summary
- Replaces manual `incrementVersion` implementation with `semver.inc()` for correct edge-case handling
- Adds `valid()` check for the `initial-version` input to fail fast on invalid semver strings
- Updates test expectations to match `semver.inc()` behavior (strips build metadata, correct pre-release handling)

Closes #99

## Test plan
- [x] All existing version increment tests updated for semver.inc behavior
- [x] New test: invalid version string throws error
- [x] New test: invalid initial-version input throws error
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)