### PR TITLE
feat: validate tag-prefix and release-branch inputs

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -274,5 +274,68 @@ describe('main', () => {
 
       await expect(run()).rejects.toThrow('Invalid initial version')
     })
+
+    it('should throw when tag-prefix exceeds 20 characters', async () => {
+      ;(getInput as Mock).mockImplementation((name: string) => {
+        switch (name) {
+          case 'github-token':
+            return 'token'
+          case 'tag-prefix':
+            return 'a-very-long-prefix-that-exceeds'
+          case 'release-branch':
+            return 'main'
+          case 'release-notes-template':
+            return ''
+          case 'initial-version':
+            return '0.1.0'
+          default:
+            return ''
+        }
+      })
+
+      await expect(run()).rejects.toThrow('tag-prefix must be at most 20 characters')
+    })
+
+    it('should throw when tag-prefix contains invalid characters', async () => {
+      ;(getInput as Mock).mockImplementation((name: string) => {
+        switch (name) {
+          case 'github-token':
+            return 'token'
+          case 'tag-prefix':
+            return 'v@#!'
+          case 'release-branch':
+            return 'main'
+          case 'release-notes-template':
+            return ''
+          case 'initial-version':
+            return '0.1.0'
+          default:
+            return ''
+        }
+      })
+
+      await expect(run()).rejects.toThrow('tag-prefix contains invalid characters')
+    })
+
+    it('should throw when release-branch is empty', async () => {
+      ;(getInput as Mock).mockImplementation((name: string) => {
+        switch (name) {
+          case 'github-token':
+            return 'token'
+          case 'tag-prefix':
+            return 'v'
+          case 'release-branch':
+            return '   '
+          case 'release-notes-template':
+            return ''
+          case 'initial-version':
+            return '0.1.0'
+          default:
+            return ''
+        }
+      })
+
+      await expect(run()).rejects.toThrow('release-branch must not be empty')
+    })
   })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -47541,6 +47541,15 @@ const run = async () => {
     if (!(0,semver.valid)(initialVersion)) {
         throw new Error(`Invalid initial version: "${initialVersion}". Must be a valid semver string (e.g., 1.0.0)`);
     }
+    if (tagPrefix.length > 20) {
+        throw new Error(`tag-prefix must be at most 20 characters (got ${String(tagPrefix.length)})`);
+    }
+    if (!/^[a-zA-Z0-9._\-/]*$/.test(tagPrefix)) {
+        throw new Error(`tag-prefix contains invalid characters: "${tagPrefix}". Only alphanumeric, dots, hyphens, underscores, and slashes are allowed`);
+    }
+    if (!releaseBranch.trim()) {
+        throw new Error('release-branch must not be empty');
+    }
     const octokit = getOctokit(token);
     const { owner, repo } = github_context.repo;
     if (!owner || !repo) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,18 @@ export const run = async (): Promise<void> => {
     throw new Error(`Invalid initial version: "${initialVersion}". Must be a valid semver string (e.g., 1.0.0)`)
   }
 
+  if (tagPrefix.length > 20) {
+    throw new Error(`tag-prefix must be at most 20 characters (got ${String(tagPrefix.length)})`)
+  }
+
+  if (!/^[a-zA-Z0-9._\-/]*$/.test(tagPrefix)) {
+    throw new Error(`tag-prefix contains invalid characters: "${tagPrefix}". Only alphanumeric, dots, hyphens, underscores, and slashes are allowed`)
+  }
+
+  if (!releaseBranch.trim()) {
+    throw new Error('release-branch must not be empty')
+  }
+
   const octokit = getOctokit(token)
   const { owner, repo } = context.repo
 


### PR DESCRIPTION
## Summary
- Validates `tag-prefix`: max 20 characters, alphanumeric/dots/hyphens/underscores/slashes only
- Validates `release-branch`: must not be empty or whitespace-only
- Fails fast with clear error messages before any API calls

Closes #100

## Test plan
- [x] Test: tag-prefix exceeding 20 characters throws
- [x] Test: tag-prefix with invalid characters throws
- [x] Test: empty release-branch throws
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)