### PR TITLE
fix(hooks): replace pnpm dlx with pnpm exec

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-pnpm dlx commitlint --edit ${1}
+pnpm exec commitlint --edit ${1}

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,1 +1,1 @@
-pnpm dlx package-changed run "pnpm install"
+pnpm exec package-changed run "pnpm install"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,1 +1,1 @@
-pnpm dlx package-changed run "pnpm install"
+pnpm exec package-changed run "pnpm install"

--- a/.husky/post-rebase
+++ b/.husky/post-rebase
@@ -1,1 +1,1 @@
-pnpm dlx package-changed run "pnpm install"
+pnpm exec package-changed run "pnpm install"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm dlx lint-staged
+pnpm exec lint-staged


### PR DESCRIPTION
## Summary
- Replaces `pnpm dlx` with `pnpm exec` in all 5 husky hooks (pre-commit, commit-msg, post-checkout, post-merge, post-rebase)
- All tools (lint-staged, commitlint, package-changed) are already devDependencies, eliminating the supply-chain risk of downloading packages at runtime

Closes #103

## Test plan
- [x] All hooks use locally installed packages
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)