### PR TITLE
feat: resolve branch SHA instead of passing HEAD string

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -59,6 +59,7 @@ describe('main', () => {
   describe('run', () => {
     it('should create initial release when no tags exist', async () => {
       ;(getTags as Mock).mockResolvedValue([])
+      mockOctokit.rest.git.getRef.mockResolvedValue({ data: { object: { sha: 'head-sha' } } })
       ;(getCommits as Mock).mockResolvedValue([
         { type: 'feat', subject: 'new feature', message: 'feat: new feature', breaking: false }
       ])
@@ -76,6 +77,12 @@ describe('main', () => {
 
       await run()
 
+      expect(mockOctokit.rest.git.getRef).toHaveBeenCalledWith({ owner: 'owner', repo: 'repo', ref: 'heads/main' })
+      expect(getCommits).toHaveBeenCalledWith(
+        { owner: 'owner', repo: 'repo', octokit: mockOctokit },
+        'head-sha',
+        undefined
+      )
       expect(createOrUpdateRelease).toHaveBeenCalledWith(
         { owner: 'owner', repo: 'repo', octokit: mockOctokit },
         'v0.1.0',
@@ -131,6 +138,7 @@ describe('main', () => {
     it('should handle dry run mode', async () => {
       ;(getBooleanInput as Mock).mockReturnValue(true)
       ;(getTags as Mock).mockResolvedValue([])
+      mockOctokit.rest.git.getRef.mockResolvedValue({ data: { object: { sha: 'head-sha' } } })
       ;(getCommits as Mock).mockResolvedValue([
         { type: 'feat', subject: 'new feature', message: 'feat: new feature', breaking: false }
       ])

--- a/dist/index.js
+++ b/dist/index.js
@@ -47564,7 +47564,8 @@ const run = async () => {
         info(`No existing tags found. Starting from version ${initialVersion}`);
         const tagName = `${tagPrefix}${initialVersion}`;
         const releaseName = initialVersion;
-        const { categorizedCommits } = await processCommits(githubContext, 'HEAD');
+        const { data: headRef } = await octokit.rest.git.getRef({ owner, repo, ref: `heads/${releaseBranch}` });
+        const { categorizedCommits } = await processCommits(githubContext, headRef.object.sha);
         const releaseNotes = compileReleaseNotes(releaseNotesTemplate, {
             version: initialVersion,
             ...categorizedCommits

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,8 @@ export const run = async (): Promise<void> => {
     const tagName = `${tagPrefix}${initialVersion}`
     const releaseName = initialVersion
 
-    const { categorizedCommits } = await processCommits(githubContext, 'HEAD')
+    const { data: headRef } = await octokit.rest.git.getRef({ owner, repo, ref: `heads/${releaseBranch}` })
+    const { categorizedCommits } = await processCommits(githubContext, headRef.object.sha)
     const releaseNotes = compileReleaseNotes(releaseNotesTemplate, {
       version: initialVersion,
       ...categorizedCommits


### PR DESCRIPTION
## Summary
- In the no-tags (initial release) path, resolves the release branch SHA via `getRef` instead of passing the undocumented `'HEAD'` string to the commits API
- Consistent with the existing-tags path which already resolves the branch SHA

Closes #112

## Test plan
- [x] Initial release test updated to mock getRef and assert resolved SHA
- [x] Dry run test updated with getRef mock
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)