### PR TITLE
feat(version): output clean version without tag prefix

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -84,7 +84,8 @@ describe('main', () => {
       )
       expect(setOutput).toHaveBeenCalledWith('release-url', 'https://github.com/owner/repo/releases/tag/v0.1.0')
       expect(setOutput).toHaveBeenCalledWith('release-id', '123')
-      expect(setOutput).toHaveBeenCalledWith('version', 'v0.1.0')
+      expect(setOutput).toHaveBeenCalledWith('version', '0.1.0')
+      expect(setOutput).toHaveBeenCalledWith('tag', 'v0.1.0')
     })
 
     it('should update release when tags exist', async () => {
@@ -125,7 +126,8 @@ describe('main', () => {
       )
       expect(setOutput).toHaveBeenCalledWith('release-url', 'https://github.com/owner/repo/releases/tag/v1.1.0')
       expect(setOutput).toHaveBeenCalledWith('release-id', '123')
-      expect(setOutput).toHaveBeenCalledWith('version', 'v1.1.0')
+      expect(setOutput).toHaveBeenCalledWith('version', '1.1.0')
+      expect(setOutput).toHaveBeenCalledWith('tag', 'v1.1.0')
     })
 
     it('should handle dry run mode', async () => {

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,8 @@ inputs:
 outputs:
   version:
     description: The calculated version for the release
+  tag:
+    description: The full tag name including prefix
   release-url:
     description: The URL of the created or updated draft release
   release-id:

--- a/dist/index.js
+++ b/dist/index.js
@@ -47580,7 +47580,8 @@ const run = async () => {
         const release = await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes);
         setOutput('release-url', release.url);
         setOutput('release-id', release.id.toString());
-        setOutput('version', release.tagName);
+        setOutput('version', initialVersion);
+        setOutput('tag', release.tagName);
         return;
     }
     const { data: tagData } = await octokit.rest.git.getRef({ owner, repo, ref: `tags/${latestTag.name}` });
@@ -47633,7 +47634,8 @@ const run = async () => {
     const release = await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes, headData.object.sha);
     setOutput('release-url', release.url);
     setOutput('release-id', release.id.toString());
-    setOutput('version', release.tagName);
+    setOutput('version', newVersion);
+    setOutput('tag', release.tagName);
 };
 
 ;// CONCATENATED MODULE: ./src/index.ts

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,8 @@ export const run = async (): Promise<void> => {
     const release = await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes)
     setOutput('release-url', release.url)
     setOutput('release-id', release.id.toString())
-    setOutput('version', release.tagName)
+    setOutput('version', initialVersion)
+    setOutput('tag', release.tagName)
     return
   }
 
@@ -136,5 +137,6 @@ export const run = async (): Promise<void> => {
 
   setOutput('release-url', release.url)
   setOutput('release-id', release.id.toString())
-  setOutput('version', release.tagName)
+  setOutput('version', newVersion)
+  setOutput('tag', release.tagName)
 }


### PR DESCRIPTION
## Summary
- Changes `version` output to emit the clean semver string (e.g., `1.0.0`) instead of the full tag name (e.g., `v1.0.0`)
- Adds new `tag` output for the full tag name including prefix
- Updates `action.yml` with the new `tag` output definition

Closes #130

## Test plan
- [x] Initial release test: version outputs clean string, tag outputs full tag
- [x] Update release test: version outputs clean string, tag outputs full tag
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)