### PR TITLE
ci: use default GITHUB_TOKEN instead of PAT

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Run Semantic Automatic Version Releaser
         uses: ./
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Replace `secrets.GH_TOKEN` (PAT) with `github.token` in the release-draft workflow
- The default token with `contents: write` permission is sufficient for managing draft releases
- Removes dependency on a separately configured PAT secret

## Test plan
- [ ] Verify the workflow runs successfully on the next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)