### PR TITLE
docs: drop license and maintainer colophon from footer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -351,18 +351,6 @@ jobs:
             <a class="btn btn-outline" href="#quick-start"><span>Copy the workflow</span></a>
           </div>
         </div>
-        <div class="footer-meta">
-          <dl class="colophon">
-            <div>
-              <dt>License</dt>
-              <dd>MIT</dd>
-            </div>
-            <div>
-              <dt>Maintainer</dt>
-              <dd>21st Digital</dd>
-            </div>
-          </dl>
-        </div>
       </footer>
     </div>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1079,35 +1079,6 @@ h1.display {
   background: var(--coral);
 }
 
-.colophon {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 18px;
-  margin: 0;
-  padding-top: 28px;
-  border-top: 1px solid var(--line);
-}
-
-.colophon div {
-  display: grid;
-  gap: 6px;
-}
-
-.colophon dt {
-  font-family: var(--mono);
-  font-size: 11px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--stone);
-}
-
-.colophon dd {
-  margin: 0;
-  font-family: var(--sans);
-  font-size: 15px;
-  font-weight: 500;
-}
-
 /* ----- Reveal on load ----- */
 
 .reveal {
@@ -1200,10 +1171,6 @@ h1.display {
   .btn {
     width: 100%;
     justify-content: center;
-  }
-
-  .colophon {
-    grid-template-columns: 1fr;
   }
 
   .section-head {


### PR DESCRIPTION
## Summary

- Remove the License / Maintainer colophon from the footer and the now-dead `.colophon` styles. Neither entry added signal — license lives in `LICENSE` + README; maintainer was redundant with the footer lead.

## Test plan

- [ ] `open docs/index.html` — footer shows display lead + CTA row only, no colophon row
- [ ] No leftover `.colophon` / `.footer-meta` references in markup or CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)