### PR TITLE
refactor(main): extract shared buildAndPublishRelease helper from run() (#255)

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { categorizeCommits, determineVersionBump } from '../src/commits.js'
 import { createOrUpdateRelease, getAnnotatedTag, getCommits, getGitRef, getTags } from '../src/github.js'
-import { run } from '../src/main.js'
+import { buildAndPublishRelease, run } from '../src/main.js'
 import { compileReleaseNotes } from '../src/templates.js'
 import { getLatestVersion, incrementVersion } from '../src/version.js'
 
@@ -464,6 +464,84 @@ describe('main', () => {
       setInputs({ 'release-branch': '   ' })
 
       await expect(run()).rejects.toThrow('release-branch must not be empty')
+    })
+  })
+
+  describe('buildAndPublishRelease', () => {
+    const githubContext = { owner: 'owner', repo: 'repo', octokit: mockOctokit } as never
+    const categorizedCommits = { features: [], fixes: [], breaking: [] }
+
+    it('compiles notes and creates the release, returning create outputs', async () => {
+      ;(compileReleaseNotes as Mock).mockReturnValue('Release notes')
+      ;(createOrUpdateRelease as Mock).mockResolvedValue({
+        url: 'https://github.com/owner/repo/releases/tag/v2.0.0',
+        id: 42,
+        tagName: 'v2.0.0'
+      })
+
+      const outputs = await buildAndPublishRelease(githubContext, {
+        version: '2.0.0',
+        tagName: 'v2.0.0',
+        releaseName: '2.0.0',
+        categorizedCommits,
+        releaseNotesTemplate: '',
+        dryRun: false,
+        dryRunMessage: 'Dry run - would create/update release with:',
+        targetCommitish: 'head-sha'
+      })
+
+      expect(compileReleaseNotes).toHaveBeenCalledWith('', { version: '2.0.0', ...categorizedCommits })
+      expect(createOrUpdateRelease).toHaveBeenCalledWith(githubContext, 'v2.0.0', '2.0.0', 'Release notes', 'head-sha')
+      expect(outputs).toEqual({
+        skipped: false,
+        releaseUrl: 'https://github.com/owner/repo/releases/tag/v2.0.0',
+        releaseId: '42',
+        version: '2.0.0',
+        tag: 'v2.0.0'
+      })
+    })
+
+    it('omits targetCommitish from the create call when not provided', async () => {
+      ;(compileReleaseNotes as Mock).mockReturnValue('Release notes')
+      ;(createOrUpdateRelease as Mock).mockResolvedValue({
+        url: 'https://github.com/owner/repo/releases/tag/v0.1.0',
+        id: 7,
+        tagName: 'v0.1.0'
+      })
+
+      await buildAndPublishRelease(githubContext, {
+        version: '0.1.0',
+        tagName: 'v0.1.0',
+        releaseName: '0.1.0',
+        categorizedCommits,
+        releaseNotesTemplate: '',
+        dryRun: false,
+        dryRunMessage: 'Dry run - would create initial release with:'
+      })
+
+      expect(createOrUpdateRelease).toHaveBeenCalledWith(githubContext, 'v0.1.0', '0.1.0', 'Release notes')
+    })
+
+    it('skips the API call and returns skipped outputs in dry-run mode', async () => {
+      ;(compileReleaseNotes as Mock).mockReturnValue('Release notes')
+
+      const outputs = await buildAndPublishRelease(githubContext, {
+        version: '2.0.0',
+        tagName: 'v2.0.0',
+        releaseName: '2.0.0',
+        categorizedCommits,
+        releaseNotesTemplate: '',
+        dryRun: true,
+        dryRunMessage: 'Dry run - would create/update release with:',
+        targetCommitish: 'head-sha'
+      })
+
+      expect(createOrUpdateRelease).not.toHaveBeenCalled()
+      expect(outputs).toEqual({
+        skipped: true,
+        version: '2.0.0',
+        tag: 'v2.0.0'
+      })
     })
   })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -56836,6 +56836,40 @@ const processCommits = async (githubContext, head, sinceTag) => {
     const categorizedCommits = categorizeCommits(commits);
     return { commits, categorizedCommits };
 };
+// Compiles release notes and either logs a dry-run preview or creates/updates
+// the draft release. Returns the outputs the caller should publish — shared by
+// the initial-release and version-bump paths in run().
+const buildAndPublishRelease = async (githubContext, options) => {
+    const { version, tagName, releaseName, categorizedCommits, releaseNotesTemplate, dryRun, dryRunMessage } = options;
+    const releaseNotes = compileReleaseNotes(releaseNotesTemplate, {
+        version,
+        ...categorizedCommits
+    });
+    if (dryRun) {
+        info(dryRunMessage);
+        info(`Version: ${version}`);
+        info('Release notes:');
+        // Sanitize release notes to prevent workflow command injection
+        info(sanitizeLogOutput(releaseNotes));
+        return {
+            skipped: true,
+            version,
+            tag: tagName
+        };
+    }
+    // Preserve the exact call arity of the two original branches: the
+    // initial-release path omits targetCommitish entirely.
+    const release = options.targetCommitish
+        ? await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes, options.targetCommitish)
+        : await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes);
+    return {
+        skipped: false,
+        releaseUrl: release.url,
+        releaseId: release.id.toString(),
+        version,
+        tag: release.tagName
+    };
+};
 const run = async () => {
     const token = getInput('github-token', { required: true });
     const tagPrefix = getInput('tag-prefix');
@@ -56884,35 +56918,17 @@ const run = async () => {
     const latestTag = getLatestVersion(tags, tagPrefix);
     if (latestTag == null) {
         info(`No existing tags found. Starting from version ${initialVersion}`);
-        const tagName = `${tagPrefix}${initialVersion}`;
-        const releaseName = initialVersion;
         const headRef = await getGitRef(githubContext, `heads/${releaseBranch}`);
         const { categorizedCommits } = await processCommits(githubContext, headRef.object.sha);
-        const releaseNotes = compileReleaseNotes(releaseNotesTemplate, {
+        setReleaseOutputs(await buildAndPublishRelease(githubContext, {
             version: initialVersion,
-            ...categorizedCommits
-        });
-        if (dryRun) {
-            info('Dry run - would create initial release with:');
-            info(`Version: ${initialVersion}`);
-            info('Release notes:');
-            // Sanitize release notes to prevent workflow command injection
-            info(sanitizeLogOutput(releaseNotes));
-            setReleaseOutputs({
-                skipped: true,
-                version: initialVersion,
-                tag: tagName
-            });
-            return;
-        }
-        const release = await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes);
-        setReleaseOutputs({
-            skipped: false,
-            releaseUrl: release.url,
-            releaseId: release.id.toString(),
-            version: initialVersion,
-            tag: release.tagName
-        });
+            tagName: `${tagPrefix}${initialVersion}`,
+            releaseName: initialVersion,
+            categorizedCommits,
+            releaseNotesTemplate,
+            dryRun,
+            dryRunMessage: 'Dry run - would create initial release with:'
+        }));
         return;
     }
     const tagData = await getGitRef(githubContext, `tags/${latestTag.name}`);
@@ -56954,33 +56970,16 @@ const run = async () => {
         return;
     }
     newVersion = incrementVersion(newVersion, versionBump);
-    const releaseNotes = compileReleaseNotes(releaseNotesTemplate, {
+    setReleaseOutputs(await buildAndPublishRelease(githubContext, {
         version: newVersion,
-        ...categorizedCommits
-    });
-    if (dryRun) {
-        info('Dry run - would create/update release with:');
-        info(`Version: ${newVersion}`);
-        info('Release notes:');
-        // Sanitize release notes to prevent workflow command injection
-        info(sanitizeLogOutput(releaseNotes));
-        setReleaseOutputs({
-            skipped: true,
-            version: newVersion,
-            tag: `${tagPrefix}${newVersion}`
-        });
-        return;
-    }
-    const tagName = `${tagPrefix}${newVersion}`;
-    const releaseName = newVersion;
-    const release = await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes, headData.object.sha);
-    setReleaseOutputs({
-        skipped: false,
-        releaseUrl: release.url,
-        releaseId: release.id.toString(),
-        version: newVersion,
-        tag: release.tagName
-    });
+        tagName: `${tagPrefix}${newVersion}`,
+        releaseName: newVersion,
+        categorizedCommits,
+        releaseNotesTemplate,
+        dryRun,
+        dryRunMessage: 'Dry run - would create/update release with:',
+        targetCommitish: headData.object.sha
+    }));
 };
 
 ;// CONCATENATED MODULE: ./src/index.ts

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { getBooleanInput, getInput, info, setOutput } from '@actions/core'
 import { context, getOctokit } from '@actions/github'
 import { valid } from 'semver'
 
-import { categorizeCommits, determineVersionBump } from './commits.js'
+import { categorizeCommits, type CategorizedCommits, determineVersionBump } from './commits.js'
 import { createOrUpdateRelease, getAnnotatedTag, getCommits, getGitRef, getTags, type GitHubContext } from './github.js'
 import { compileReleaseNotes } from './templates.js'
 import { sanitizeLogOutput } from './utils.js'
@@ -14,6 +14,17 @@ interface ReleaseOutputs {
   tag: string
   releaseUrl?: string
   releaseId?: string
+}
+
+interface BuildReleaseOptions {
+  version: string
+  tagName: string
+  releaseName: string
+  categorizedCommits: CategorizedCommits
+  releaseNotesTemplate: string
+  dryRun: boolean
+  dryRunMessage: string
+  targetCommitish?: string
 }
 
 const BRANCH_REF_PREFIX = 'refs/heads/'
@@ -31,6 +42,48 @@ const processCommits = async (githubContext: GitHubContext, head: string, sinceT
 
   const categorizedCommits = categorizeCommits(commits)
   return { commits, categorizedCommits }
+}
+
+// Compiles release notes and either logs a dry-run preview or creates/updates
+// the draft release. Returns the outputs the caller should publish — shared by
+// the initial-release and version-bump paths in run().
+export const buildAndPublishRelease = async (
+  githubContext: GitHubContext,
+  options: BuildReleaseOptions
+): Promise<ReleaseOutputs> => {
+  const { version, tagName, releaseName, categorizedCommits, releaseNotesTemplate, dryRun, dryRunMessage } = options
+
+  const releaseNotes = compileReleaseNotes(releaseNotesTemplate, {
+    version,
+    ...categorizedCommits
+  })
+
+  if (dryRun) {
+    info(dryRunMessage)
+    info(`Version: ${version}`)
+    info('Release notes:')
+    // Sanitize release notes to prevent workflow command injection
+    info(sanitizeLogOutput(releaseNotes))
+    return {
+      skipped: true,
+      version,
+      tag: tagName
+    }
+  }
+
+  // Preserve the exact call arity of the two original branches: the
+  // initial-release path omits targetCommitish entirely.
+  const release = options.targetCommitish
+    ? await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes, options.targetCommitish)
+    : await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes)
+
+  return {
+    skipped: false,
+    releaseUrl: release.url,
+    releaseId: release.id.toString(),
+    version,
+    tag: release.tagName
+  }
 }
 
 export const run = async (): Promise<void> => {
@@ -97,38 +150,21 @@ export const run = async (): Promise<void> => {
 
   if (latestTag == null) {
     info(`No existing tags found. Starting from version ${initialVersion}`)
-    const tagName = `${tagPrefix}${initialVersion}`
-    const releaseName = initialVersion
 
     const headRef = await getGitRef(githubContext, `heads/${releaseBranch}`)
     const { categorizedCommits } = await processCommits(githubContext, headRef.object.sha)
-    const releaseNotes = compileReleaseNotes(releaseNotesTemplate, {
-      version: initialVersion,
-      ...categorizedCommits
-    })
 
-    if (dryRun) {
-      info('Dry run - would create initial release with:')
-      info(`Version: ${initialVersion}`)
-      info('Release notes:')
-      // Sanitize release notes to prevent workflow command injection
-      info(sanitizeLogOutput(releaseNotes))
-      setReleaseOutputs({
-        skipped: true,
+    setReleaseOutputs(
+      await buildAndPublishRelease(githubContext, {
         version: initialVersion,
-        tag: tagName
+        tagName: `${tagPrefix}${initialVersion}`,
+        releaseName: initialVersion,
+        categorizedCommits,
+        releaseNotesTemplate,
+        dryRun,
+        dryRunMessage: 'Dry run - would create initial release with:'
       })
-      return
-    }
-
-    const release = await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes)
-    setReleaseOutputs({
-      skipped: false,
-      releaseUrl: release.url,
-      releaseId: release.id.toString(),
-      version: initialVersion,
-      tag: release.tagName
-    })
+    )
     return
   }
 
@@ -182,35 +218,16 @@ export const run = async (): Promise<void> => {
 
   newVersion = incrementVersion(newVersion, versionBump)
 
-  const releaseNotes = compileReleaseNotes(releaseNotesTemplate, {
-    version: newVersion,
-    ...categorizedCommits
-  })
-
-  if (dryRun) {
-    info('Dry run - would create/update release with:')
-    info(`Version: ${newVersion}`)
-    info('Release notes:')
-    // Sanitize release notes to prevent workflow command injection
-    info(sanitizeLogOutput(releaseNotes))
-    setReleaseOutputs({
-      skipped: true,
+  setReleaseOutputs(
+    await buildAndPublishRelease(githubContext, {
       version: newVersion,
-      tag: `${tagPrefix}${newVersion}`
+      tagName: `${tagPrefix}${newVersion}`,
+      releaseName: newVersion,
+      categorizedCommits,
+      releaseNotesTemplate,
+      dryRun,
+      dryRunMessage: 'Dry run - would create/update release with:',
+      targetCommitish: headData.object.sha
     })
-    return
-  }
-
-  const tagName = `${tagPrefix}${newVersion}`
-  const releaseName = newVersion
-
-  const release = await createOrUpdateRelease(githubContext, tagName, releaseName, releaseNotes, headData.object.sha)
-
-  setReleaseOutputs({
-    skipped: false,
-    releaseUrl: release.url,
-    releaseId: release.id.toString(),
-    version: newVersion,
-    tag: release.tagName
-  })
+  )
 }


### PR DESCRIPTION
## Summary

Closes #255.

`run()` in `src/main.ts` was a single ~180-line function whose two branches — the initial-release path and the version-bump path — duplicated ~90 lines of near-identical compile-notes / dry-run / create-and-set-outputs logic.

This extracts that shared tail into a new exported `buildAndPublishRelease()` helper that returns `ReleaseOutputs`. `run()` now reduces to: validate inputs → resolve branch/refs → decide version (initial vs bump) → `setReleaseOutputs(await buildAndPublishRelease(...))`.

## Behavior preserved (pure refactor)

- The initial-release path still calls `createOrUpdateRelease` with **4 args** (no `targetCommitish`) via a ternary, preserving exact call arity that the existing tests assert on.
- Both distinct dry-run log messages are retained.
- Identical tag/version output shapes in every branch.

## Tests

- Added 3 direct unit tests targeting the new helper seam (create path, omitted-`targetCommitish` path, dry-run path).
- Full suite: **119 passed** (`main.test.ts` 16 → 19).
- `tsc --noEmit` clean (src + test configs); ESLint and Prettier clean.
- Workflow-backed code review at high effort: 8 candidate findings, all 8 refuted on verification — no surviving findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)