### PR TITLE
docs: record Dependabot major update policy

### DIFF
--- a/docs/adr/0002-dependabot-major-updates-are-manual.md
+++ b/docs/adr/0002-dependabot-major-updates-are-manual.md
@@ -1,0 +1,7 @@
+# Keep Dependabot major updates manual
+
+Dependabot auto-merge stays limited to patch and minor dependency updates. Major updates can carry breaking changes even when CI is green, so they need human review before merge; open major Dependabot PRs are therefore expected and do not indicate a broken auto-merge rule.
+
+## Status
+
+accepted


### PR DESCRIPTION
## Summary

- Add an ADR documenting that Dependabot auto-merge remains limited to patch and minor updates.
- Clarify that major dependency updates are expected to stay open for human review because they can carry breaking changes even when CI is green.

## Validation

- `git commit` ran the configured lint-staged/prettier hook for the new Markdown file.