### PR TITLE
fix(deps): bump undici security override

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -56,7 +56,7 @@ const http = __importStar(__nccwpck_require__(8611));
 const https = __importStar(__nccwpck_require__(5692));
 const pm = __importStar(__nccwpck_require__(8835));
 const tunnel = __importStar(__nccwpck_require__(1410));
-const undici_1 = __nccwpck_require__(193);
+const undici_1 = __nccwpck_require__(3241);
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -4892,7 +4892,7 @@ var _helpersEach = __nccwpck_require__(7064);
 
 var _helpersEach2 = _interopRequireDefault(_helpersEach);
 
-var _helpersHelperMissing = __nccwpck_require__(7162);
+var _helpersHelperMissing = __nccwpck_require__(3191);
 
 var _helpersHelperMissing2 = _interopRequireDefault(_helpersHelperMissing);
 
@@ -5093,7 +5093,7 @@ module.exports = exports['default'];
 
 /***/ }),
 
-/***/ 7162:
+/***/ 3191:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 
@@ -6441,7 +6441,7 @@ const {
   tildeTrimReplace,
   caretTrimReplace,
 } = __nccwpck_require__(7643)
-const { FLAG_INCLUDE_PRERELEASE, FLAG_LOOSE } = __nccwpck_require__(2801)
+const { FLAG_INCLUDE_PRERELEASE, FLAG_LOOSE } = __nccwpck_require__(5182)
 
 const isNullSet = c => c.value === '<0.0.0-0'
 const isAny = c => c.value === ''
@@ -6778,7 +6778,7 @@ const testSet = (set, version, options) => {
 
 
 const debug = __nccwpck_require__(147)
-const { MAX_LENGTH, MAX_SAFE_INTEGER } = __nccwpck_require__(2801)
+const { MAX_LENGTH, MAX_SAFE_INTEGER } = __nccwpck_require__(5182)
 const { safeRe: re, t } = __nccwpck_require__(7643)
 
 const parseOptions = __nccwpck_require__(7152)
@@ -7133,7 +7133,7 @@ module.exports = clean
 
 
 const eq = __nccwpck_require__(1670)
-const neq = __nccwpck_require__(8029)
+const neq = __nccwpck_require__(410)
 const gt = __nccwpck_require__(8107)
 const gte = __nccwpck_require__(440)
 const lt = __nccwpck_require__(3076)
@@ -7478,7 +7478,7 @@ module.exports = minor
 
 /***/ }),
 
-/***/ 8029:
+/***/ 410:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -7619,7 +7619,7 @@ module.exports = valid
 
 // just pre-load all the stuff that index.js lazily exports
 const internalRe = __nccwpck_require__(7643)
-const constants = __nccwpck_require__(2801)
+const constants = __nccwpck_require__(5182)
 const SemVer = __nccwpck_require__(2735)
 const identifiers = __nccwpck_require__(5216)
 const parse = __nccwpck_require__(8549)
@@ -7640,7 +7640,7 @@ const rsort = __nccwpck_require__(6676)
 const gt = __nccwpck_require__(8107)
 const lt = __nccwpck_require__(3076)
 const eq = __nccwpck_require__(1670)
-const neq = __nccwpck_require__(8029)
+const neq = __nccwpck_require__(410)
 const gte = __nccwpck_require__(440)
 const lte = __nccwpck_require__(3713)
 const cmp = __nccwpck_require__(2666)
@@ -7650,7 +7650,7 @@ const Range = __nccwpck_require__(9666)
 const satisfies = __nccwpck_require__(9647)
 const toComparators = __nccwpck_require__(1978)
 const maxSatisfying = __nccwpck_require__(7373)
-const minSatisfying = __nccwpck_require__(572)
+const minSatisfying = __nccwpck_require__(8191)
 const minVersion = __nccwpck_require__(1630)
 const validRange = __nccwpck_require__(5557)
 const outside = __nccwpck_require__(4124)
@@ -7710,7 +7710,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2801:
+/***/ 5182:
 /***/ ((module) => {
 
 
@@ -7890,7 +7890,7 @@ const {
   MAX_SAFE_COMPONENT_LENGTH,
   MAX_SAFE_BUILD_LENGTH,
   MAX_LENGTH,
-} = __nccwpck_require__(2801)
+} = __nccwpck_require__(5182)
 const debug = __nccwpck_require__(147)
 exports = module.exports = {}
 
@@ -8187,7 +8187,7 @@ module.exports = maxSatisfying
 
 /***/ }),
 
-/***/ 572:
+/***/ 8191:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -12196,37 +12196,37 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 193:
+/***/ 3241:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const Client = __nccwpck_require__(5856)
-const Dispatcher = __nccwpck_require__(410)
-const Pool = __nccwpck_require__(1037)
-const BalancedPool = __nccwpck_require__(8562)
-const RoundRobinPool = __nccwpck_require__(3313)
-const Agent = __nccwpck_require__(2542)
-const ProxyAgent = __nccwpck_require__(9287)
-const Socks5ProxyAgent = __nccwpck_require__(574)
-const EnvHttpProxyAgent = __nccwpck_require__(3356)
-const RetryAgent = __nccwpck_require__(9181)
-const H2CClient = __nccwpck_require__(4738)
-const errors = __nccwpck_require__(8450)
-const util = __nccwpck_require__(9741)
+const Client = __nccwpck_require__(9448)
+const Dispatcher = __nccwpck_require__(6530)
+const Pool = __nccwpck_require__(8261)
+const BalancedPool = __nccwpck_require__(8170)
+const RoundRobinPool = __nccwpck_require__(4409)
+const Agent = __nccwpck_require__(4742)
+const ProxyAgent = __nccwpck_require__(1679)
+const Socks5ProxyAgent = __nccwpck_require__(5318)
+const EnvHttpProxyAgent = __nccwpck_require__(7652)
+const RetryAgent = __nccwpck_require__(9061)
+const H2CClient = __nccwpck_require__(6282)
+const errors = __nccwpck_require__(9370)
+const util = __nccwpck_require__(6469)
 const { InvalidArgumentError } = errors
-const api = __nccwpck_require__(7626)
-const buildConnector = __nccwpck_require__(8811)
-const MockClient = __nccwpck_require__(5022)
-const { MockCallHistory, MockCallHistoryLog } = __nccwpck_require__(4636)
-const MockAgent = __nccwpck_require__(3016)
-const MockPool = __nccwpck_require__(8227)
-const SnapshotAgent = __nccwpck_require__(5758)
-const mockErrors = __nccwpck_require__(1242)
-const RetryHandler = __nccwpck_require__(4801)
-const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(8598)
-const DecoratorHandler = __nccwpck_require__(1794)
-const RedirectHandler = __nccwpck_require__(825)
+const api = __nccwpck_require__(4418)
+const buildConnector = __nccwpck_require__(1555)
+const MockClient = __nccwpck_require__(8854)
+const { MockCallHistory, MockCallHistoryLog } = __nccwpck_require__(9876)
+const MockAgent = __nccwpck_require__(9328)
+const MockPool = __nccwpck_require__(4187)
+const SnapshotAgent = __nccwpck_require__(3430)
+const mockErrors = __nccwpck_require__(9029)
+const RetryHandler = __nccwpck_require__(953)
+const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(6798)
+const DecoratorHandler = __nccwpck_require__(6586)
+const RedirectHandler = __nccwpck_require__(2737)
 
 Object.assign(Dispatcher.prototype, api)
 
@@ -12246,21 +12246,21 @@ module.exports.RetryHandler = RetryHandler
 module.exports.DecoratorHandler = DecoratorHandler
 module.exports.RedirectHandler = RedirectHandler
 module.exports.interceptors = {
-  redirect: __nccwpck_require__(1981),
-  responseError: __nccwpck_require__(6357),
-  retry: __nccwpck_require__(9147),
-  dump: __nccwpck_require__(9427),
-  dns: __nccwpck_require__(6978),
-  cache: __nccwpck_require__(6555),
-  decompress: __nccwpck_require__(4826),
-  deduplicate: __nccwpck_require__(4733)
+  redirect: __nccwpck_require__(1861),
+  responseError: __nccwpck_require__(5037),
+  retry: __nccwpck_require__(3939),
+  dump: __nccwpck_require__(5995),
+  dns: __nccwpck_require__(7066),
+  cache: __nccwpck_require__(6291),
+  decompress: __nccwpck_require__(2818),
+  deduplicate: __nccwpck_require__(805)
 }
 
 module.exports.cacheStores = {
-  MemoryCacheStore: __nccwpck_require__(9726)
+  MemoryCacheStore: __nccwpck_require__(6518)
 }
 
-const SqliteCacheStore = __nccwpck_require__(8793)
+const SqliteCacheStore = __nccwpck_require__(2801)
 module.exports.cacheStores.SqliteCacheStore = SqliteCacheStore
 
 module.exports.buildConnector = buildConnector
@@ -12322,7 +12322,7 @@ function makeDispatcher (fn) {
 module.exports.setGlobalDispatcher = setGlobalDispatcher
 module.exports.getGlobalDispatcher = getGlobalDispatcher
 
-const fetchImpl = (__nccwpck_require__(5251).fetch)
+const fetchImpl = (__nccwpck_require__(5691).fetch)
 
 // Capture __filename at module load time for stack trace augmentation.
 // This may be undefined when bundled in environments like Node.js internals.
@@ -12362,22 +12362,22 @@ module.exports.fetch = function fetch (init, options = undefined) {
     throw err
   })
 }
-module.exports.Headers = __nccwpck_require__(6293).Headers
-module.exports.Response = __nccwpck_require__(444).Response
-module.exports.Request = __nccwpck_require__(1602).Request
-module.exports.FormData = __nccwpck_require__(9097).FormData
+module.exports.Headers = __nccwpck_require__(7418).Headers
+module.exports.Response = __nccwpck_require__(3268).Response
+module.exports.Request = __nccwpck_require__(7530).Request
+module.exports.FormData = __nccwpck_require__(4017).FormData
 
-const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(2756)
+const { setGlobalOrigin, getGlobalOrigin } = __nccwpck_require__(1564)
 
 module.exports.setGlobalOrigin = setGlobalOrigin
 module.exports.getGlobalOrigin = getGlobalOrigin
 
-const { CacheStorage } = __nccwpck_require__(8378)
-const { kConstruct } = __nccwpck_require__(836)
+const { CacheStorage } = __nccwpck_require__(7842)
+const { kConstruct } = __nccwpck_require__(3916)
 
 module.exports.caches = new CacheStorage(kConstruct)
 
-const { deleteCookie, getCookies, getSetCookies, setCookie, parseCookie } = __nccwpck_require__(8520)
+const { deleteCookie, getCookies, getSetCookies, setCookie, parseCookie } = __nccwpck_require__(1856)
 
 module.exports.deleteCookie = deleteCookie
 module.exports.getCookies = getCookies
@@ -12385,21 +12385,21 @@ module.exports.getSetCookies = getSetCookies
 module.exports.setCookie = setCookie
 module.exports.parseCookie = parseCookie
 
-const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(8847)
+const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(7127)
 
 module.exports.parseMIMEType = parseMIMEType
 module.exports.serializeAMimeType = serializeAMimeType
 
-const { CloseEvent, ErrorEvent, MessageEvent } = __nccwpck_require__(7063)
-const { WebSocket, ping } = __nccwpck_require__(6264)
+const { CloseEvent, ErrorEvent, MessageEvent } = __nccwpck_require__(6943)
+const { WebSocket, ping } = __nccwpck_require__(1027)
 module.exports.WebSocket = WebSocket
 module.exports.CloseEvent = CloseEvent
 module.exports.ErrorEvent = ErrorEvent
 module.exports.MessageEvent = MessageEvent
 module.exports.ping = ping
 
-module.exports.WebSocketStream = __nccwpck_require__(3262).WebSocketStream
-module.exports.WebSocketError = __nccwpck_require__(3234).WebSocketError
+module.exports.WebSocketStream = __nccwpck_require__(9798).WebSocketStream
+module.exports.WebSocketError = __nccwpck_require__(1914).WebSocketError
 
 module.exports.request = makeDispatcher(api.request)
 module.exports.stream = makeDispatcher(api.stream)
@@ -12415,7 +12415,7 @@ module.exports.MockAgent = MockAgent
 module.exports.SnapshotAgent = SnapshotAgent
 module.exports.mockErrors = mockErrors
 
-const { EventSource } = __nccwpck_require__(1123)
+const { EventSource } = __nccwpck_require__(1499)
 
 module.exports.EventSource = EventSource
 
@@ -12437,13 +12437,13 @@ module.exports.install = install
 
 /***/ }),
 
-/***/ 6769:
+/***/ 6249:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { addAbortListener } = __nccwpck_require__(9741)
-const { RequestAbortedError } = __nccwpck_require__(8450)
+const { addAbortListener } = __nccwpck_require__(6469)
+const { RequestAbortedError } = __nccwpck_require__(9370)
 
 const kListener = Symbol('kListener')
 const kSignal = Symbol('kSignal')
@@ -12503,16 +12503,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 605:
+/***/ 6805:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const assert = __nccwpck_require__(4589)
 const { AsyncResource } = __nccwpck_require__(6698)
-const { InvalidArgumentError, SocketError } = __nccwpck_require__(8450)
-const util = __nccwpck_require__(9741)
-const { addSignal, removeSignal } = __nccwpck_require__(6769)
+const { InvalidArgumentError, SocketError } = __nccwpck_require__(9370)
+const util = __nccwpck_require__(6469)
+const { addSignal, removeSignal } = __nccwpck_require__(6249)
 
 class ConnectHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -12620,7 +12620,7 @@ module.exports = connect
 
 /***/ }),
 
-/***/ 5493:
+/***/ 6653:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -12636,9 +12636,9 @@ const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = __nccwpck_require__(8450)
-const util = __nccwpck_require__(9741)
-const { addSignal, removeSignal } = __nccwpck_require__(6769)
+} = __nccwpck_require__(9370)
+const util = __nccwpck_require__(6469)
+const { addSignal, removeSignal } = __nccwpck_require__(6249)
 
 function noop () {}
 
@@ -12879,16 +12879,16 @@ module.exports = pipeline
 
 /***/ }),
 
-/***/ 118:
+/***/ 3278:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const assert = __nccwpck_require__(4589)
 const { AsyncResource } = __nccwpck_require__(6698)
-const { Readable } = __nccwpck_require__(2432)
-const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(8450)
-const util = __nccwpck_require__(9741)
+const { Readable } = __nccwpck_require__(1432)
+const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(9370)
+const util = __nccwpck_require__(6469)
 
 function noop () {}
 
@@ -12905,7 +12905,7 @@ class RequestHandler extends AsyncResource {
         throw new InvalidArgumentError('invalid callback')
       }
 
-      if (highWaterMark && (typeof highWaterMark !== 'number' || highWaterMark < 0)) {
+      if (highWaterMark != null && (!Number.isFinite(highWaterMark) || highWaterMark < 0)) {
         throw new InvalidArgumentError('invalid highWaterMark')
       }
 
@@ -13100,7 +13100,7 @@ module.exports.RequestHandler = RequestHandler
 
 /***/ }),
 
-/***/ 9291:
+/***/ 1907:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -13108,9 +13108,9 @@ module.exports.RequestHandler = RequestHandler
 const assert = __nccwpck_require__(4589)
 const { finished } = __nccwpck_require__(7075)
 const { AsyncResource } = __nccwpck_require__(6698)
-const { InvalidArgumentError, InvalidReturnValueError } = __nccwpck_require__(8450)
-const util = __nccwpck_require__(9741)
-const { addSignal, removeSignal } = __nccwpck_require__(6769)
+const { InvalidArgumentError, InvalidReturnValueError } = __nccwpck_require__(9370)
+const util = __nccwpck_require__(6469)
+const { addSignal, removeSignal } = __nccwpck_require__(6249)
 
 function noop () {}
 
@@ -13316,17 +13316,17 @@ module.exports = stream
 
 /***/ }),
 
-/***/ 3711:
+/***/ 1143:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { InvalidArgumentError, SocketError } = __nccwpck_require__(8450)
+const { InvalidArgumentError, SocketError } = __nccwpck_require__(9370)
 const { AsyncResource } = __nccwpck_require__(6698)
 const assert = __nccwpck_require__(4589)
-const util = __nccwpck_require__(9741)
-const { kHTTP2Stream } = __nccwpck_require__(836)
-const { addSignal, removeSignal } = __nccwpck_require__(6769)
+const util = __nccwpck_require__(6469)
+const { kHTTP2Stream } = __nccwpck_require__(3916)
+const { addSignal, removeSignal } = __nccwpck_require__(6249)
 
 class UpgradeHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -13434,30 +13434,30 @@ module.exports = upgrade
 
 /***/ }),
 
-/***/ 7626:
+/***/ 4418:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-module.exports.request = __nccwpck_require__(118)
-module.exports.stream = __nccwpck_require__(9291)
-module.exports.pipeline = __nccwpck_require__(5493)
-module.exports.upgrade = __nccwpck_require__(3711)
-module.exports.connect = __nccwpck_require__(605)
+module.exports.request = __nccwpck_require__(3278)
+module.exports.stream = __nccwpck_require__(1907)
+module.exports.pipeline = __nccwpck_require__(6653)
+module.exports.upgrade = __nccwpck_require__(1143)
+module.exports.connect = __nccwpck_require__(6805)
 
 
 /***/ }),
 
-/***/ 2432:
+/***/ 1432:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const assert = __nccwpck_require__(4589)
 const { Readable } = __nccwpck_require__(7075)
-const { RequestAbortedError, NotSupportedError, InvalidArgumentError, AbortError } = __nccwpck_require__(8450)
-const util = __nccwpck_require__(9741)
-const { ReadableStreamFrom } = __nccwpck_require__(9741)
+const { RequestAbortedError, NotSupportedError, InvalidArgumentError, AbortError } = __nccwpck_require__(9370)
+const util = __nccwpck_require__(6469)
+const { ReadableStreamFrom } = __nccwpck_require__(6469)
 
 const kConsume = Symbol('kConsume')
 const kReading = Symbol('kReading')
@@ -14035,14 +14035,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9726:
+/***/ 6518:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const { Writable } = __nccwpck_require__(7075)
 const { EventEmitter } = __nccwpck_require__(8474)
-const { assertCacheKey, assertCacheValue } = __nccwpck_require__(8956)
+const { assertCacheKey, assertCacheValue } = __nccwpck_require__(8772)
 
 /**
  * @typedef {import('../../types/cache-interceptor.d.ts').default.CacheKey} CacheKey
@@ -14276,13 +14276,13 @@ module.exports = MemoryCacheStore
 
 /***/ }),
 
-/***/ 8793:
+/***/ 2801:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const { Writable } = __nccwpck_require__(7075)
-const { assertCacheKey, assertCacheValue } = __nccwpck_require__(8956)
+const { assertCacheKey, assertCacheValue } = __nccwpck_require__(8772)
 
 let DatabaseSync
 
@@ -14497,7 +14497,7 @@ module.exports = class SqliteCacheStore {
           SELECT
             id
           FROM cacheInterceptorV${VERSION}
-          ORDER BY cachedAt DESC
+          ORDER BY cachedAt ASC
           LIMIT ?
         )
       `)
@@ -14564,7 +14564,6 @@ module.exports = class SqliteCacheStore {
         existingValue.id
       )
     } else {
-      this.#prune()
       // New response, let's insert it
       this.#insertValueQuery.run(
         url,
@@ -14580,6 +14579,7 @@ module.exports = class SqliteCacheStore {
         value.cachedAt,
         value.staleAt
       )
+      this.#prune()
     }
   }
 
@@ -14690,7 +14690,7 @@ module.exports = class SqliteCacheStore {
     const now = Date.now()
     for (const value of values) {
       if (now >= value.deleteAt && !canBeExpired) {
-        return undefined
+        continue
       }
 
       let matches = true
@@ -14744,15 +14744,15 @@ function headerValueEquals (lhs, rhs) {
 
 /***/ }),
 
-/***/ 8811:
+/***/ 1555:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const net = __nccwpck_require__(7030)
 const assert = __nccwpck_require__(4589)
-const util = __nccwpck_require__(9741)
-const { InvalidArgumentError } = __nccwpck_require__(8450)
+const util = __nccwpck_require__(6469)
+const { InvalidArgumentError } = __nccwpck_require__(9370)
 
 let tls // include tls conditionally since it is not always available
 
@@ -14785,6 +14785,22 @@ const SessionCache = class WeakSessionCache {
   set (sessionKey, session) {
     if (this._maxCachedSessions === 0) {
       return
+    }
+
+    if (this._sessionCache.has(sessionKey)) {
+      this._sessionCache.delete(sessionKey)
+    } else if (this._sessionCache.size >= this._maxCachedSessions) {
+      for (const [key, ref] of this._sessionCache) {
+        if (ref.deref() === undefined) {
+          this._sessionCache.delete(key)
+          return
+        }
+      }
+
+      const oldest = this._sessionCache.keys().next()
+      if (!oldest.done) {
+        this._sessionCache.delete(oldest.value)
+      }
     }
 
     this._sessionCache.set(sessionKey, new WeakRef(session))
@@ -14888,7 +14904,7 @@ module.exports = buildConnector
 
 /***/ }),
 
-/***/ 2004:
+/***/ 1388:
 /***/ ((module) => {
 
 
@@ -15038,7 +15054,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1257:
+/***/ 8369:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -15220,10 +15236,12 @@ function trackWebSocketEvents (debugLog = websocketDebuglog) {
 
   diagnosticsChannel.subscribe('undici:websocket:open',
     evt => {
-      const {
-        address: { address, port }
-      } = evt
-      debugLog('connection opened %s%s', address, port ? `:${port}` : '')
+      if (evt.address != null) {
+        const { address, port } = evt.address
+        debugLog('connection opened %s%s', address, port ? `:${port}` : '')
+      } else {
+        debugLog('connection opened')
+      }
     })
 
   diagnosticsChannel.subscribe('undici:websocket:close',
@@ -15270,7 +15288,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8450:
+/***/ 9370:
 /***/ ((module) => {
 
 
@@ -15754,7 +15772,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2920:
+/***/ 8928:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -15762,7 +15780,7 @@ module.exports = {
 const {
   InvalidArgumentError,
   NotSupportedError
-} = __nccwpck_require__(8450)
+} = __nccwpck_require__(9370)
 const assert = __nccwpck_require__(4589)
 const {
   isValidHTTPToken,
@@ -15779,12 +15797,27 @@ const {
   getServerName,
   normalizedMethodRecords,
   getProtocolFromUrlString
-} = __nccwpck_require__(9741)
-const { channels } = __nccwpck_require__(1257)
-const { headerNameLowerCasedRecord } = __nccwpck_require__(2004)
+} = __nccwpck_require__(6469)
+const { channels } = __nccwpck_require__(8369)
+const { headerNameLowerCasedRecord } = __nccwpck_require__(1388)
 
 // Verifies that a given path is valid does not contain control chars \x00 to \x20
 const invalidPathRegex = /[^\u0021-\u00ff]/
+
+function isValidContentLengthHeaderValue (val) {
+  if (typeof val !== 'string' || val.length === 0) {
+    return false
+  }
+
+  for (let i = 0; i < val.length; i++) {
+    const charCode = val.charCodeAt(i)
+    if (charCode < 48 || charCode > 57) {
+      return false
+    }
+  }
+
+  return true
+}
 
 const kHandler = Symbol('handler')
 
@@ -16161,23 +16194,31 @@ function processHeader (request, key, val) {
     if (request.contentLength !== null) {
       throw new InvalidArgumentError('duplicate content-length header')
     }
-    request.contentLength = parseInt(val, 10)
-    if (!Number.isFinite(request.contentLength)) {
+    if (!isValidContentLengthHeaderValue(val)) {
       throw new InvalidArgumentError('invalid content-length header')
     }
+    request.contentLength = parseInt(val, 10)
   } else if (request.contentType === null && headerName === 'content-type') {
     request.contentType = val
     request.headers.push(key, val)
   } else if (headerName === 'transfer-encoding' || headerName === 'keep-alive' || headerName === 'upgrade') {
     throw new InvalidArgumentError(`invalid ${headerName} header`)
   } else if (headerName === 'connection') {
-    const value = typeof val === 'string' ? val.toLowerCase() : null
-    if (value !== 'close' && value !== 'keep-alive') {
+    // Per RFC 7230 Section 6.1, Connection header can contain
+    // a comma-separated list of connection option tokens (header names)
+    const value = typeof val === 'string' ? val : null
+    if (value === null) {
       throw new InvalidArgumentError('invalid connection header')
     }
 
-    if (value === 'close') {
-      request.reset = true
+    for (const token of value.toLowerCase().split(',')) {
+      const trimmed = token.trim()
+      if (!isValidHTTPToken(trimmed)) {
+        throw new InvalidArgumentError('invalid connection header')
+      }
+      if (trimmed === 'close') {
+        request.reset = true
+      }
     }
   } else if (headerName === 'expect') {
     throw new NotSupportedError('expect header not supported')
@@ -16191,18 +16232,19 @@ module.exports = Request
 
 /***/ }),
 
-/***/ 7333:
+/***/ 7213:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const { EventEmitter } = __nccwpck_require__(8474)
 const { Buffer } = __nccwpck_require__(4573)
-const { InvalidArgumentError, Socks5ProxyError } = __nccwpck_require__(8450)
+const { InvalidArgumentError, Socks5ProxyError } = __nccwpck_require__(9370)
 const { debuglog } = __nccwpck_require__(7975)
-const { parseAddress } = __nccwpck_require__(9093)
+const { parseAddress } = __nccwpck_require__(493)
 
 const debug = debuglog('undici:socks5')
+const EMPTY_BUFFER = Buffer.alloc(0)
 
 // SOCKS5 constants
 const SOCKS_VERSION = 0x05
@@ -16247,6 +16289,7 @@ const STATES = {
   INITIAL: 'initial',
   HANDSHAKING: 'handshaking',
   AUTHENTICATING: 'authenticating',
+  AUTHENTICATED: 'authenticated',
   CONNECTING: 'connecting',
   CONNECTED: 'connected',
   ERROR: 'error',
@@ -16268,7 +16311,10 @@ class Socks5Client extends EventEmitter {
     this.socket = socket
     this.options = options
     this.state = STATES.INITIAL
-    this.buffer = Buffer.alloc(0)
+    this.buffer = EMPTY_BUFFER
+    this.onSocketData = this.onData.bind(this)
+    this.onSocketError = this.onError.bind(this)
+    this.onSocketClose = this.onClose.bind(this)
 
     // Authentication settings
     this.authMethods = []
@@ -16278,9 +16324,9 @@ class Socks5Client extends EventEmitter {
     this.authMethods.push(AUTH_METHODS.NO_AUTH)
 
     // Socket event handlers
-    this.socket.on('data', this.onData.bind(this))
-    this.socket.on('error', this.onError.bind(this))
-    this.socket.on('close', this.onClose.bind(this))
+    this.socket.on('data', this.onSocketData)
+    this.socket.on('error', this.onSocketError)
+    this.socket.on('close', this.onSocketClose)
   }
 
   /**
@@ -16335,6 +16381,11 @@ class Socks5Client extends EventEmitter {
     }
   }
 
+  markAuthenticated () {
+    this.state = STATES.AUTHENTICATED
+    this.emit('authenticated')
+  }
+
   /**
    * Start the SOCKS5 handshake
    */
@@ -16385,7 +16436,7 @@ class Socks5Client extends EventEmitter {
     debug('server selected auth method', method)
 
     if (method === AUTH_METHODS.NO_AUTH) {
-      this.emit('authenticated')
+      this.markAuthenticated()
     } else if (method === AUTH_METHODS.USERNAME_PASSWORD) {
       this.state = STATES.AUTHENTICATING
       this.sendAuthRequest()
@@ -16450,7 +16501,7 @@ class Socks5Client extends EventEmitter {
 
     this.buffer = this.buffer.subarray(2)
     debug('authentication successful')
-    this.emit('authenticated')
+    this.markAuthenticated()
   }
 
   /**
@@ -16459,8 +16510,12 @@ class Socks5Client extends EventEmitter {
    * @param {number} port - Target port
    */
   connect (address, port) {
-    if (this.state === STATES.CONNECTED) {
-      throw new InvalidArgumentError('Already connected')
+    if (this.state === STATES.CONNECTING || this.state === STATES.CONNECTED) {
+      throw new InvalidArgumentError('Connection already in progress')
+    }
+
+    if (this.state !== STATES.AUTHENTICATED) {
+      throw new InvalidArgumentError('Client must be authenticated before CONNECT')
     }
 
     debug('connecting to', address, port)
@@ -16559,8 +16614,9 @@ class Socks5Client extends EventEmitter {
 
     const boundPort = this.buffer.readUInt16BE(offset)
 
-    this.buffer = this.buffer.subarray(responseLength)
+    this.buffer = EMPTY_BUFFER
     this.state = STATES.CONNECTED
+    this.socket.removeListener('data', this.onSocketData)
 
     debug('connected, bound address:', boundAddress, 'port:', boundPort)
     this.emit('connected', { address: boundAddress, port: boundPort })
@@ -16605,14 +16661,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9093:
+/***/ 493:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const { Buffer } = __nccwpck_require__(4573)
 const net = __nccwpck_require__(7030)
-const { InvalidArgumentError } = __nccwpck_require__(8450)
+const { InvalidArgumentError } = __nccwpck_require__(9370)
 
 /**
  * Parse an address and determine its type
@@ -16656,34 +16712,43 @@ function parseAddress (address) {
  */
 function parseIPv6 (address) {
   const buffer = Buffer.alloc(16)
-  const parts = address.split(':')
-  let partIndex = 0
-  let bufferIndex = 0
+  let normalizedAddress = address
+
+  // Expand an embedded IPv4 tail into the last two IPv6 groups.
+  if (address.includes('.')) {
+    const lastColonIndex = address.lastIndexOf(':')
+    const ipv4Part = address.slice(lastColonIndex + 1)
+
+    if (net.isIPv4(ipv4Part)) {
+      const octets = ipv4Part.split('.').map(Number)
+      const high = ((octets[0] << 8) | octets[1]).toString(16)
+      const low = ((octets[2] << 8) | octets[3]).toString(16)
+      normalizedAddress = `${address.slice(0, lastColonIndex)}:${high}:${low}`
+    }
+  }
 
   // Handle compressed notation (::)
-  const doubleColonIndex = address.indexOf('::')
+  const doubleColonIndex = normalizedAddress.indexOf('::')
   if (doubleColonIndex !== -1) {
-    // Count non-empty parts
-    const nonEmptyParts = parts.filter(p => p.length > 0).length
-    const skipParts = 8 - nonEmptyParts
+    const before = normalizedAddress.slice(0, doubleColonIndex)
+    const after = normalizedAddress.slice(doubleColonIndex + 2)
+    const beforeParts = before === '' ? [] : before.split(':')
+    const afterParts = after === '' ? [] : after.split(':')
 
-    for (let i = 0; i < parts.length; i++) {
-      if (parts[i] === '' && i === doubleColonIndex / 3) {
-        // Skip empty parts for ::
-        bufferIndex += skipParts * 2
-      } else if (parts[i] !== '') {
-        const value = parseInt(parts[i], 16)
-        buffer.writeUInt16BE(value, bufferIndex)
-        bufferIndex += 2
-      }
+    let bufferIndex = 0
+    for (const part of beforeParts) {
+      buffer.writeUInt16BE(parseInt(part, 16), bufferIndex)
+      bufferIndex += 2
+    }
+    bufferIndex = 16 - afterParts.length * 2
+    for (const part of afterParts) {
+      buffer.writeUInt16BE(parseInt(part, 16), bufferIndex)
+      bufferIndex += 2
     }
   } else {
-    // No compression, parse normally
-    for (const part of parts) {
-      if (part === '') continue
-      const value = parseInt(part, 16)
-      buffer.writeUInt16BE(value, partIndex * 2)
-      partIndex++
+    const parts = normalizedAddress.split(':')
+    for (let i = 0; i < parts.length; i++) {
+      buffer.writeUInt16BE(parseInt(parts[i], 16), i * 2)
     }
   }
 
@@ -16815,7 +16880,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 836:
+/***/ 3916:
 /***/ ((module) => {
 
 
@@ -16897,7 +16962,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7621:
+/***/ 7229:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -16905,7 +16970,7 @@ module.exports = {
 const {
   wellknownHeaderNames,
   headerNameLowerCasedRecord
-} = __nccwpck_require__(2004)
+} = __nccwpck_require__(1388)
 
 class TstNode {
   /** @type {any} */
@@ -17064,22 +17129,22 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9741:
+/***/ 6469:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const assert = __nccwpck_require__(4589)
-const { kDestroyed, kBodyUsed, kListeners, kBody } = __nccwpck_require__(836)
+const { kDestroyed, kBodyUsed, kListeners, kBody } = __nccwpck_require__(3916)
 const { IncomingMessage } = __nccwpck_require__(7067)
 const stream = __nccwpck_require__(7075)
 const net = __nccwpck_require__(7030)
 const { stringify } = __nccwpck_require__(1792)
 const { EventEmitter: EE } = __nccwpck_require__(8474)
-const timers = __nccwpck_require__(7130)
-const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(8450)
-const { headerNameLowerCasedRecord } = __nccwpck_require__(2004)
-const { tree } = __nccwpck_require__(7621)
+const timers = __nccwpck_require__(8434)
+const { InvalidArgumentError, ConnectTimeoutError } = __nccwpck_require__(9370)
+const { headerNameLowerCasedRecord } = __nccwpck_require__(1388)
+const { tree } = __nccwpck_require__(7229)
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.', 2).map(v => Number(v))
 
@@ -17509,19 +17574,39 @@ function parseHeaders (headers, obj) {
     const key = headerNameToString(headers[i])
     let val = obj[key]
 
-    if (val) {
-      if (typeof val === 'string') {
-        val = [val]
-        obj[key] = val
-      }
-      val.push(headers[i + 1].toString('latin1'))
-    } else {
-      const headersValue = headers[i + 1]
-      if (typeof headersValue === 'string') {
-        obj[key] = headersValue
+    if (val !== undefined) {
+      if (!Object.hasOwn(obj, key)) {
+        const headersValue = typeof headers[i + 1] === 'string'
+          ? headers[i + 1]
+          : Array.isArray(headers[i + 1])
+            ? headers[i + 1].map(x => x.toString('latin1'))
+            : headers[i + 1].toString('latin1')
+
+        if (key === '__proto__') {
+          Object.defineProperty(obj, key, {
+            value: headersValue,
+            enumerable: true,
+            configurable: true,
+            writable: true
+          })
+        } else {
+          obj[key] = headersValue
+        }
       } else {
-        obj[key] = Array.isArray(headersValue) ? headersValue.map(x => x.toString('latin1')) : headersValue.toString('latin1')
+        if (typeof val === 'string') {
+          val = [val]
+          obj[key] = val
+        }
+        val.push(headers[i + 1].toString('latin1'))
       }
+    } else {
+      const headersValue = typeof headers[i + 1] === 'string'
+        ? headers[i + 1]
+        : Array.isArray(headers[i + 1])
+          ? headers[i + 1].map(x => x.toString('latin1'))
+          : headers[i + 1].toString('latin1')
+
+      obj[key] = headersValue
     }
   }
 
@@ -18043,17 +18128,17 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2542:
+/***/ 4742:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { InvalidArgumentError, MaxOriginsReachedError } = __nccwpck_require__(8450)
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kUrl } = __nccwpck_require__(836)
-const DispatcherBase = __nccwpck_require__(3570)
-const Pool = __nccwpck_require__(1037)
-const Client = __nccwpck_require__(5856)
-const util = __nccwpck_require__(9741)
+const { InvalidArgumentError, MaxOriginsReachedError } = __nccwpck_require__(9370)
+const { kClients, kRunning, kClose, kDestroy, kDispatch, kUrl } = __nccwpck_require__(3916)
+const DispatcherBase = __nccwpck_require__(4922)
+const Pool = __nccwpck_require__(8261)
+const Client = __nccwpck_require__(9448)
+const util = __nccwpck_require__(6469)
 
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
@@ -18083,7 +18168,7 @@ class Agent extends DispatcherBase {
       throw new InvalidArgumentError('maxOrigins must be a number greater than 0')
     }
 
-    super()
+    super(options)
 
     if (connect && typeof connect !== 'function') {
       connect = { ...connect }
@@ -18208,7 +18293,7 @@ module.exports = Agent
 
 /***/ }),
 
-/***/ 8562:
+/***/ 8170:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -18216,7 +18301,7 @@ module.exports = Agent
 const {
   BalancedPoolMissingUpstreamError,
   InvalidArgumentError
-} = __nccwpck_require__(8450)
+} = __nccwpck_require__(9370)
 const {
   PoolBase,
   kClients,
@@ -18224,10 +18309,10 @@ const {
   kAddClient,
   kRemoveClient,
   kGetDispatcher
-} = __nccwpck_require__(8191)
-const Pool = __nccwpck_require__(1037)
-const { kUrl } = __nccwpck_require__(836)
-const util = __nccwpck_require__(9741)
+} = __nccwpck_require__(2903)
+const Pool = __nccwpck_require__(8261)
+const { kUrl } = __nccwpck_require__(3916)
+const util = __nccwpck_require__(6469)
 const kFactory = Symbol('factory')
 
 const kOptions = Symbol('options')
@@ -18267,7 +18352,7 @@ class BalancedPool extends PoolBase {
       throw new InvalidArgumentError('factory must be a function.')
     }
 
-    super()
+    super(opts)
 
     this[kOptions] = { ...util.deepClone(opts) }
     this[kOptions].interceptors = opts.interceptors
@@ -18434,7 +18519,7 @@ module.exports = BalancedPool
 
 /***/ }),
 
-/***/ 7870:
+/***/ 4678:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -18442,9 +18527,9 @@ module.exports = BalancedPool
 /* global WebAssembly */
 
 const assert = __nccwpck_require__(4589)
-const util = __nccwpck_require__(9741)
-const { channels } = __nccwpck_require__(1257)
-const timers = __nccwpck_require__(7130)
+const util = __nccwpck_require__(6469)
+const { channels } = __nccwpck_require__(8369)
+const timers = __nccwpck_require__(8434)
 const {
   RequestContentLengthMismatchError,
   ResponseContentLengthMismatchError,
@@ -18456,7 +18541,7 @@ const {
   BodyTimeoutError,
   HTTPParserError,
   ResponseExceededMaxSizeError
-} = __nccwpck_require__(8450)
+} = __nccwpck_require__(9370)
 const {
   kUrl,
   kReset,
@@ -18490,17 +18575,20 @@ const {
   kResume,
   kHTTPContext,
   kClosed
-} = __nccwpck_require__(836)
+} = __nccwpck_require__(3916)
 
-const constants = __nccwpck_require__(9455)
+const constants = __nccwpck_require__(7687)
 const EMPTY_BUF = Buffer.alloc(0)
 const FastBuffer = Buffer[Symbol.species]
 const removeAllListeners = util.removeAllListeners
+const kIdleSocketValidation = Symbol('kIdleSocketValidation')
+const kIdleSocketValidationTimeout = Symbol('kIdleSocketValidationTimeout')
+const kSocketUsed = Symbol('kSocketUsed')
 
 let extractBody
 
 function lazyllhttp () {
-  const llhttpWasmData = process.env.JEST_WORKER_ID ? __nccwpck_require__(1721) : undefined
+  const llhttpWasmData = process.env.JEST_WORKER_ID ? __nccwpck_require__(1633) : undefined
 
   let mod
 
@@ -18508,14 +18596,14 @@ function lazyllhttp () {
   let useWasmSIMD = process.arch !== 'ppc64'
   // The Env Variable UNDICI_NO_WASM_SIMD allows explicitly overriding the default behavior
   if (process.env.UNDICI_NO_WASM_SIMD === '1') {
-    useWasmSIMD = true
-  } else if (process.env.UNDICI_NO_WASM_SIMD === '0') {
     useWasmSIMD = false
+  } else if (process.env.UNDICI_NO_WASM_SIMD === '0') {
+    useWasmSIMD = true
   }
 
   if (useWasmSIMD) {
     try {
-      mod = new WebAssembly.Module(__nccwpck_require__(5867))
+      mod = new WebAssembly.Module(__nccwpck_require__(3011))
     } catch {
     }
   }
@@ -18525,7 +18613,7 @@ function lazyllhttp () {
     // being enabled, but the occurring of this other error
     // * https://github.com/emscripten-core/emscripten/issues/11495
     // got me to remove that check to avoid breaking Node 12.
-    mod = new WebAssembly.Module(llhttpWasmData || __nccwpck_require__(1721))
+    mod = new WebAssembly.Module(llhttpWasmData || __nccwpck_require__(1633))
   }
 
   return new WebAssembly.Instance(mod, {
@@ -18655,6 +18743,7 @@ class Parser {
      */
     this.socket = socket
     this.timeout = null
+    this.timeoutWeakRef = new WeakRef(this)
     this.timeoutValue = null
     this.timeoutType = null
     this.statusCode = 0
@@ -18692,9 +18781,9 @@ class Parser {
 
       if (delay) {
         if (type & USE_FAST_TIMER) {
-          this.timeout = timers.setFastTimeout(onParserTimeout, delay, new WeakRef(this))
+          this.timeout = timers.setFastTimeout(onParserTimeout, delay, this.timeoutWeakRef)
         } else {
-          this.timeout = setTimeout(onParserTimeout, delay, new WeakRef(this))
+          this.timeout = setTimeout(onParserTimeout, delay, this.timeoutWeakRef)
           this.timeout?.unref()
         }
       }
@@ -18788,21 +18877,60 @@ class Parser {
           this.paused = true
           socket.unshift(data)
         } else {
-          const ptr = llhttp.llhttp_get_error_reason(this.ptr)
-          let message = ''
-          if (ptr) {
-            const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0)
-            message =
-              'Response does not match the HTTP/1.1 protocol (' +
-              Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
-              ')'
-          }
-          throw new HTTPParserError(message, constants.ERROR[ret], data)
+          throw this.createError(ret, data)
         }
       }
     } catch (err) {
       util.destroy(socket, err)
     }
+  }
+
+  finish () {
+    assert(currentParser === null)
+    assert(this.ptr != null)
+    assert(!this.paused)
+
+    const { llhttp } = this
+
+    let ret
+
+    try {
+      currentParser = this
+      ret = llhttp.llhttp_finish(this.ptr)
+    } finally {
+      currentParser = null
+    }
+
+    if (ret === constants.ERROR.OK) {
+      return null
+    }
+
+    if (ret === constants.ERROR.PAUSED || ret === constants.ERROR.PAUSED_UPGRADE) {
+      this.paused = true
+      return null
+    }
+
+    return this.createError(ret, EMPTY_BUF)
+  }
+
+  createError (ret, data) {
+    const { llhttp, contentLength, bytesRead } = this
+
+    if (contentLength && bytesRead !== parseInt(contentLength, 10)) {
+      return new ResponseContentLengthMismatchError()
+    }
+
+    const ptr = llhttp.llhttp_get_error_reason(this.ptr)
+    let message = ''
+    if (ptr) {
+      const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0)
+      message =
+        'Response does not match the HTTP/1.1 protocol (' +
+        Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
+        ')'
+    }
+
+    return new HTTPParserError(message, constants.ERROR[ret], data)
   }
 
   destroy () {
@@ -18836,6 +18964,11 @@ class Parser {
     const { socket, client } = this
 
     if (socket.destroyed) {
+      return -1
+    }
+
+    if (client[kRunning] === 0) {
+      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)))
       return -1
     }
 
@@ -18964,6 +19097,11 @@ class Parser {
     const { client, socket, headers, statusText } = this
 
     if (socket.destroyed) {
+      return -1
+    }
+
+    if (client[kRunning] === 0) {
+      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)))
       return -1
     }
 
@@ -19145,6 +19283,7 @@ class Parser {
     request.onComplete(headers)
 
     client[kQueue][client[kRunningIdx]++] = null
+    socket[kSocketUsed] = client[kPending] === 0
 
     if (socket[kWriting]) {
       assert(client[kRunning] === 0)
@@ -19221,6 +19360,9 @@ function connectH1 (client, socket) {
   socket[kWriting] = false
   socket[kReset] = false
   socket[kBlocking] = false
+  socket[kIdleSocketValidation] = 0
+  socket[kIdleSocketValidationTimeout] = null
+  socket[kSocketUsed] = false
   socket[kParser] = new Parser(client, socket, llhttpInstance)
 
   util.addListener(socket, 'error', onHttpSocketError)
@@ -19263,7 +19405,7 @@ function connectH1 (client, socket) {
      * @returns {boolean}
      */
     busy (request) {
-      if (socket[kWriting] || socket[kReset] || socket[kBlocking]) {
+      if (socket[kWriting] || socket[kReset] || socket[kBlocking] || socket[kIdleSocketValidation] === 1) {
         return true
       }
 
@@ -19309,8 +19451,11 @@ function onHttpSocketError (err) {
   // On Mac OS, we get an ECONNRESET even if there is a full body to be forwarded
   // to the user.
   if (err.code === 'ECONNRESET' && parser.statusCode && !parser.shouldKeepAlive) {
-    // We treat all incoming data so for as a valid response.
-    parser.onMessageComplete()
+    const parserErr = parser.finish()
+    if (parserErr) {
+      this[kError] = parserErr
+      this[kClient][kOnError](parserErr)
+    }
     return
   }
 
@@ -19327,8 +19472,10 @@ function onHttpSocketEnd () {
   const parser = this[kParser]
 
   if (parser.statusCode && !parser.shouldKeepAlive) {
-    // We treat all incoming data so far as a valid response.
-    parser.onMessageComplete()
+    const parserErr = parser.finish()
+    if (parserErr) {
+      util.destroy(this, parserErr)
+    }
     return
   }
 
@@ -19338,10 +19485,11 @@ function onHttpSocketEnd () {
 function onHttpSocketClose () {
   const parser = this[kParser]
 
+  clearIdleSocketValidation(this)
+
   if (parser) {
     if (!this[kError] && parser.statusCode && !parser.shouldKeepAlive) {
-      // We treat all incoming data so far as a valid response.
-      parser.onMessageComplete()
+      this[kError] = parser.finish() || this[kError]
     }
 
     this[kParser].destroy()
@@ -19385,6 +19533,28 @@ function onSocketClose () {
   this[kClosed] = true
 }
 
+function clearIdleSocketValidation (socket) {
+  if (socket[kIdleSocketValidationTimeout]) {
+    clearTimeout(socket[kIdleSocketValidationTimeout])
+    socket[kIdleSocketValidationTimeout] = null
+  }
+
+  socket[kIdleSocketValidation] = 0
+}
+
+function scheduleIdleSocketValidation (client, socket) {
+  socket[kIdleSocketValidation] = 1
+  socket[kIdleSocketValidationTimeout] = setTimeout(() => {
+    socket[kIdleSocketValidationTimeout] = null
+    socket[kIdleSocketValidation] = 2
+
+    if (client[kSocket] === socket && !socket.destroyed) {
+      client[kResume]()
+    }
+  }, 0)
+  socket[kIdleSocketValidationTimeout].unref?.()
+}
+
 /**
  * @param {import('./client.js')} client
  */
@@ -19400,6 +19570,32 @@ function resumeH1 (client) {
     } else if (socket[kNoRef] && socket.ref) {
       socket.ref()
       socket[kNoRef] = false
+    }
+
+    if (client[kRunning] === 0 && client[kPending] > 0 && socket[kSocketUsed]) {
+      if (socket[kIdleSocketValidation] === 0) {
+        scheduleIdleSocketValidation(client, socket)
+        socket[kParser].readMore()
+        if (socket.destroyed) {
+          return
+        }
+        return
+      }
+
+      if (socket[kIdleSocketValidation] === 1) {
+        socket[kParser].readMore()
+        if (socket.destroyed) {
+          return
+        }
+        return
+      }
+    }
+
+    if (client[kRunning] === 0) {
+      socket[kParser].readMore()
+      if (socket.destroyed) {
+        return
+      }
     }
 
     if (client[kSize] === 0) {
@@ -19453,7 +19649,7 @@ function writeH1 (client, request) {
 
   if (util.isFormDataLike(body)) {
     if (!extractBody) {
-      extractBody = (__nccwpck_require__(867).extractBody)
+      extractBody = (__nccwpck_require__(6075).extractBody)
     }
 
     const [bodyStream, contentType] = extractBody(body)
@@ -19500,6 +19696,7 @@ function writeH1 (client, request) {
   }
 
   const socket = client[kSocket]
+  clearIdleSocketValidation(socket)
 
   /**
    * @param {Error} [err]
@@ -20051,21 +20248,21 @@ module.exports = connectH1
 
 /***/ }),
 
-/***/ 3883:
+/***/ 8147:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const assert = __nccwpck_require__(4589)
 const { pipeline } = __nccwpck_require__(7075)
-const util = __nccwpck_require__(9741)
+const util = __nccwpck_require__(6469)
 const {
   RequestContentLengthMismatchError,
   RequestAbortedError,
   SocketError,
   InformationalError,
   InvalidArgumentError
-} = __nccwpck_require__(8450)
+} = __nccwpck_require__(9370)
 const {
   kUrl,
   kReset,
@@ -20093,8 +20290,8 @@ const {
   kRemoteSettings,
   kHTTP2Stream,
   kHTTP2SessionState
-} = __nccwpck_require__(836)
-const { channels } = __nccwpck_require__(1257)
+} = __nccwpck_require__(3916)
+const { channels } = __nccwpck_require__(8369)
 
 const kOpenStreams = Symbol('open streams')
 
@@ -20665,7 +20862,7 @@ function writeH2 (client, request) {
   let contentLength = util.bodyLength(body)
 
   if (util.isFormDataLike(body)) {
-    extractBody ??= (__nccwpck_require__(867).extractBody)
+    extractBody ??= (__nccwpck_require__(6075).extractBody)
 
     const [bodyStream, contentType] = extractBody(body)
     headers['content-type'] = contentType
@@ -21053,7 +21250,7 @@ module.exports = connectH2
 
 /***/ }),
 
-/***/ 5856:
+/***/ 9448:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -21061,17 +21258,17 @@ module.exports = connectH2
 const assert = __nccwpck_require__(4589)
 const net = __nccwpck_require__(7030)
 const http = __nccwpck_require__(7067)
-const util = __nccwpck_require__(9741)
-const { ClientStats } = __nccwpck_require__(4345)
-const { channels } = __nccwpck_require__(1257)
-const Request = __nccwpck_require__(2920)
-const DispatcherBase = __nccwpck_require__(3570)
+const util = __nccwpck_require__(6469)
+const { ClientStats } = __nccwpck_require__(9969)
+const { channels } = __nccwpck_require__(8369)
+const Request = __nccwpck_require__(8928)
+const DispatcherBase = __nccwpck_require__(4922)
 const {
   InvalidArgumentError,
   InformationalError,
   ClientDestroyedError
-} = __nccwpck_require__(8450)
-const buildConnector = __nccwpck_require__(8811)
+} = __nccwpck_require__(9370)
+const buildConnector = __nccwpck_require__(1555)
 const {
   kUrl,
   kServerName,
@@ -21114,9 +21311,9 @@ const {
   kHTTP2ConnectionWindowSize,
   kResume,
   kPingInterval
-} = __nccwpck_require__(836)
-const connectH1 = __nccwpck_require__(7870)
-const connectH2 = __nccwpck_require__(3883)
+} = __nccwpck_require__(3916)
+const connectH1 = __nccwpck_require__(4678)
+const connectH2 = __nccwpck_require__(8147)
 
 const kClosedResolve = Symbol('kClosedResolve')
 
@@ -21172,7 +21369,8 @@ class Client extends DispatcherBase {
     useH2c,
     initialWindowSize,
     connectionWindowSize,
-    pingInterval
+    pingInterval,
+    webSocket
   } = {}) {
     if (keepAlive !== undefined) {
       throw new InvalidArgumentError('unsupported keepAlive, use pipelining=0 instead')
@@ -21280,7 +21478,7 @@ class Client extends DispatcherBase {
       throw new InvalidArgumentError('pingInterval must be a positive integer, greater or equal to 0')
     }
 
-    super()
+    super({ webSocket })
 
     if (typeof connect !== 'function') {
       connect = buildConnector({
@@ -21293,9 +21491,13 @@ class Client extends DispatcherBase {
         ...(typeof autoSelectFamily === 'boolean' ? { autoSelectFamily, autoSelectFamilyAttemptTimeout } : undefined),
         ...connect
       })
-    } else if (socketPath != null) {
+    } else {
       const customConnect = connect
-      connect = (opts, callback) => customConnect({ ...opts, socketPath }, callback)
+      connect = (opts, callback) => customConnect({
+        ...opts,
+        ...(socketPath != null ? { socketPath } : null),
+        ...(allowH2 != null ? { allowH2 } : null)
+      }, callback)
     }
 
     this[kUrl] = util.parseOrigin(url)
@@ -21510,65 +21712,70 @@ function connect (client) {
     })
   }
 
-  client[kConnector]({
-    host,
-    hostname,
-    protocol,
-    port,
-    servername: client[kServerName],
-    localAddress: client[kLocalAddress]
-  }, (err, socket) => {
-    if (err) {
-      handleConnectError(client, err, { host, hostname, protocol, port })
+  try {
+    client[kConnector]({
+      host,
+      hostname,
+      protocol,
+      port,
+      servername: client[kServerName],
+      localAddress: client[kLocalAddress]
+    }, (err, socket) => {
+      if (err) {
+        handleConnectError(client, err, { host, hostname, protocol, port })
+        client[kResume]()
+        return
+      }
+
+      if (client.destroyed) {
+        util.destroy(socket.on('error', noop), new ClientDestroyedError())
+        client[kResume]()
+        return
+      }
+
+      assert(socket)
+
+      try {
+        client[kHTTPContext] = socket.alpnProtocol === 'h2'
+          ? connectH2(client, socket)
+          : connectH1(client, socket)
+      } catch (err) {
+        socket.destroy().on('error', noop)
+        handleConnectError(client, err, { host, hostname, protocol, port })
+        client[kResume]()
+        return
+      }
+
+      client[kConnecting] = false
+
+      socket[kCounter] = 0
+      socket[kMaxRequests] = client[kMaxRequests]
+      socket[kClient] = client
+      socket[kError] = null
+
+      if (channels.connected.hasSubscribers) {
+        channels.connected.publish({
+          connectParams: {
+            host,
+            hostname,
+            protocol,
+            port,
+            version: client[kHTTPContext]?.version,
+            servername: client[kServerName],
+            localAddress: client[kLocalAddress]
+          },
+          connector: client[kConnector],
+          socket
+        })
+      }
+
+      client.emit('connect', client[kUrl], [client])
       client[kResume]()
-      return
-    }
-
-    if (client.destroyed) {
-      util.destroy(socket.on('error', noop), new ClientDestroyedError())
-      client[kResume]()
-      return
-    }
-
-    assert(socket)
-
-    try {
-      client[kHTTPContext] = socket.alpnProtocol === 'h2'
-        ? connectH2(client, socket)
-        : connectH1(client, socket)
-    } catch (err) {
-      socket.destroy().on('error', noop)
-      handleConnectError(client, err, { host, hostname, protocol, port })
-      client[kResume]()
-      return
-    }
-
-    client[kConnecting] = false
-
-    socket[kCounter] = 0
-    socket[kMaxRequests] = client[kMaxRequests]
-    socket[kClient] = client
-    socket[kError] = null
-
-    if (channels.connected.hasSubscribers) {
-      channels.connected.publish({
-        connectParams: {
-          host,
-          hostname,
-          protocol,
-          port,
-          version: client[kHTTPContext]?.version,
-          servername: client[kServerName],
-          localAddress: client[kLocalAddress]
-        },
-        connector: client[kConnector],
-        socket
-      })
-    }
-
-    client.emit('connect', client[kUrl], [client])
+    })
+  } catch (err) {
+    handleConnectError(client, err, { host, hostname, protocol, port })
     client[kResume]()
-  })
+  }
 }
 
 function handleConnectError (client, err, { host, hostname, protocol, port }) {
@@ -21714,22 +21921,23 @@ module.exports = Client
 
 /***/ }),
 
-/***/ 3570:
+/***/ 4922:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const Dispatcher = __nccwpck_require__(410)
-const UnwrapHandler = __nccwpck_require__(2926)
+const Dispatcher = __nccwpck_require__(6530)
+const UnwrapHandler = __nccwpck_require__(7974)
 const {
   ClientDestroyedError,
   ClientClosedError,
   InvalidArgumentError
-} = __nccwpck_require__(8450)
-const { kDestroy, kClose, kClosed, kDestroyed, kDispatch } = __nccwpck_require__(836)
+} = __nccwpck_require__(9370)
+const { kDestroy, kClose, kClosed, kDestroyed, kDispatch } = __nccwpck_require__(3916)
 
 const kOnDestroyed = Symbol('onDestroyed')
 const kOnClosed = Symbol('onClosed')
+const kWebSocketOptions = Symbol('webSocketOptions')
 
 class DispatcherBase extends Dispatcher {
   /** @type {boolean} */
@@ -21743,6 +21951,24 @@ class DispatcherBase extends Dispatcher {
 
   /** @type {Array<Function>|null} */
   [kOnClosed] = null
+
+  /**
+   * @param {import('../../types/dispatcher').DispatcherOptions} [opts]
+   */
+  constructor (opts) {
+    super()
+    this[kWebSocketOptions] = opts?.webSocket ?? {}
+  }
+
+  /**
+   * @returns {import('../../types/dispatcher').WebSocketOptions}
+   */
+  get webSocketOptions () {
+    return {
+      maxFragments: this[kWebSocketOptions].maxFragments ?? 131072,
+      maxPayloadSize: this[kWebSocketOptions].maxPayloadSize ?? 128 * 1024 * 1024 // 128 MB default
+    }
+  }
 
   /** @returns {boolean} */
   get destroyed () {
@@ -21886,12 +22112,12 @@ module.exports = DispatcherBase
 
 /***/ }),
 
-/***/ 410:
+/***/ 6530:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 const EventEmitter = __nccwpck_require__(8474)
-const WrapHandler = __nccwpck_require__(633)
+const WrapHandler = __nccwpck_require__(7873)
 
 const wrapInterceptor = (dispatch) => (opts, handler) => dispatch(opts, WrapHandler.wrap(handler))
 
@@ -21941,15 +22167,15 @@ module.exports = Dispatcher
 
 /***/ }),
 
-/***/ 3356:
+/***/ 7652:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const DispatcherBase = __nccwpck_require__(3570)
-const { kClose, kDestroy, kClosed, kDestroyed, kDispatch, kNoProxyAgent, kHttpProxyAgent, kHttpsProxyAgent } = __nccwpck_require__(836)
-const ProxyAgent = __nccwpck_require__(9287)
-const Agent = __nccwpck_require__(2542)
+const DispatcherBase = __nccwpck_require__(4922)
+const { kClose, kDestroy, kClosed, kDestroyed, kDispatch, kNoProxyAgent, kHttpProxyAgent, kHttpsProxyAgent } = __nccwpck_require__(3916)
+const ProxyAgent = __nccwpck_require__(1679)
+const Agent = __nccwpck_require__(4742)
 
 const DEFAULT_PORTS = {
   'http:': 80,
@@ -22094,7 +22320,7 @@ module.exports = EnvHttpProxyAgent
 
 /***/ }),
 
-/***/ 6283:
+/***/ 2947:
 /***/ ((module) => {
 
 
@@ -22236,13 +22462,13 @@ module.exports = class FixedQueue {
 
 /***/ }),
 
-/***/ 4738:
+/***/ 6282:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { InvalidArgumentError } = __nccwpck_require__(8450)
-const Client = __nccwpck_require__(5856)
+const { InvalidArgumentError } = __nccwpck_require__(9370)
+const Client = __nccwpck_require__(9448)
 
 class H2CClient extends Client {
   constructor (origin, clientOpts) {
@@ -22256,7 +22482,7 @@ class H2CClient extends Client {
       )
     }
 
-    const { connect, maxConcurrentStreams, pipelining, ...opts } =
+    const { maxConcurrentStreams, pipelining, ...opts } =
             clientOpts ?? {}
     let defaultMaxConcurrentStreams = 100
     let defaultPipelining = 100
@@ -22294,15 +22520,15 @@ module.exports = H2CClient
 
 /***/ }),
 
-/***/ 8191:
+/***/ 2903:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { PoolStats } = __nccwpck_require__(4345)
-const DispatcherBase = __nccwpck_require__(3570)
-const FixedQueue = __nccwpck_require__(6283)
-const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(836)
+const { PoolStats } = __nccwpck_require__(9969)
+const DispatcherBase = __nccwpck_require__(4922)
+const FixedQueue = __nccwpck_require__(2947)
+const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = __nccwpck_require__(3916)
 
 const kClients = Symbol('clients')
 const kNeedDrain = Symbol('needDrain')
@@ -22515,7 +22741,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1037:
+/***/ 8261:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -22527,14 +22753,14 @@ const {
   kAddClient,
   kGetDispatcher,
   kRemoveClient
-} = __nccwpck_require__(8191)
-const Client = __nccwpck_require__(5856)
+} = __nccwpck_require__(2903)
+const Client = __nccwpck_require__(9448)
 const {
   InvalidArgumentError
-} = __nccwpck_require__(8450)
-const util = __nccwpck_require__(9741)
-const { kUrl } = __nccwpck_require__(836)
-const buildConnector = __nccwpck_require__(8811)
+} = __nccwpck_require__(9370)
+const util = __nccwpck_require__(6469)
+const { kUrl } = __nccwpck_require__(3916)
+const buildConnector = __nccwpck_require__(1555)
 
 const kOptions = Symbol('options')
 const kConnections = Symbol('connections')
@@ -22583,7 +22809,7 @@ class Pool extends PoolBase {
       })
     }
 
-    super()
+    super(options)
 
     this[kConnections] = connections || null
     this[kUrl] = util.parseOrigin(origin)
@@ -22640,20 +22866,20 @@ module.exports = Pool
 
 /***/ }),
 
-/***/ 9287:
+/***/ 1679:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { kProxy, kClose, kDestroy, kDispatch } = __nccwpck_require__(836)
-const Agent = __nccwpck_require__(2542)
-const Pool = __nccwpck_require__(1037)
-const DispatcherBase = __nccwpck_require__(3570)
-const { InvalidArgumentError, RequestAbortedError, SecureProxyConnectionError } = __nccwpck_require__(8450)
-const buildConnector = __nccwpck_require__(8811)
-const Client = __nccwpck_require__(5856)
-const { channels } = __nccwpck_require__(1257)
-const Socks5ProxyAgent = __nccwpck_require__(574)
+const { kProxy, kClose, kDestroy, kDispatch } = __nccwpck_require__(3916)
+const Agent = __nccwpck_require__(4742)
+const Pool = __nccwpck_require__(8261)
+const DispatcherBase = __nccwpck_require__(4922)
+const { InvalidArgumentError, RequestAbortedError, SecureProxyConnectionError } = __nccwpck_require__(9370)
+const buildConnector = __nccwpck_require__(1555)
+const Client = __nccwpck_require__(9448)
+const { channels } = __nccwpck_require__(8369)
+const Socks5ProxyAgent = __nccwpck_require__(5318)
 
 const kAgent = Symbol('proxy agent')
 const kClient = Symbol('proxy client')
@@ -22787,7 +23013,8 @@ class ProxyAgent extends DispatcherBase {
           factory: agentFactory,
           username: opts.username || username,
           password: opts.password || password,
-          proxyTls: opts.proxyTls
+          proxyTls: opts.proxyTls,
+          requestTls: opts.requestTls
         })
       }
 
@@ -22965,13 +23192,13 @@ module.exports = ProxyAgent
 
 /***/ }),
 
-/***/ 9181:
+/***/ 9061:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const Dispatcher = __nccwpck_require__(410)
-const RetryHandler = __nccwpck_require__(4801)
+const Dispatcher = __nccwpck_require__(6530)
+const RetryHandler = __nccwpck_require__(953)
 
 class RetryAgent extends Dispatcher {
   #agent = null
@@ -23007,7 +23234,7 @@ module.exports = RetryAgent
 
 /***/ }),
 
-/***/ 3313:
+/***/ 4409:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -23019,14 +23246,14 @@ const {
   kAddClient,
   kGetDispatcher,
   kRemoveClient
-} = __nccwpck_require__(8191)
-const Client = __nccwpck_require__(5856)
+} = __nccwpck_require__(2903)
+const Client = __nccwpck_require__(9448)
 const {
   InvalidArgumentError
-} = __nccwpck_require__(8450)
-const util = __nccwpck_require__(9741)
-const { kUrl } = __nccwpck_require__(836)
-const buildConnector = __nccwpck_require__(8811)
+} = __nccwpck_require__(9370)
+const util = __nccwpck_require__(6469)
+const { kUrl } = __nccwpck_require__(3916)
+const buildConnector = __nccwpck_require__(1555)
 
 const kOptions = Symbol('options')
 const kConnections = Symbol('connections')
@@ -23151,21 +23378,20 @@ module.exports = RoundRobinPool
 
 /***/ }),
 
-/***/ 574:
+/***/ 5318:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const net = __nccwpck_require__(7030)
 const { URL } = __nccwpck_require__(3136)
 
 let tls // include tls conditionally since it is not always available
-const DispatcherBase = __nccwpck_require__(3570)
-const { InvalidArgumentError } = __nccwpck_require__(8450)
-const { Socks5Client } = __nccwpck_require__(7333)
-const { kDispatch, kClose, kDestroy } = __nccwpck_require__(836)
-const Pool = __nccwpck_require__(1037)
-const buildConnector = __nccwpck_require__(8811)
+const DispatcherBase = __nccwpck_require__(4922)
+const { InvalidArgumentError } = __nccwpck_require__(9370)
+const { Socks5Client, STATES } = __nccwpck_require__(7213)
+const { kDispatch, kClose, kDestroy } = __nccwpck_require__(3916)
+const Pool = __nccwpck_require__(8261)
+const buildConnector = __nccwpck_require__(1555)
 const { debuglog } = __nccwpck_require__(7975)
 
 const debug = debuglog('undici:socks5-proxy')
@@ -23173,8 +23399,10 @@ const debug = debuglog('undici:socks5-proxy')
 const kProxyUrl = Symbol('proxy url')
 const kProxyHeaders = Symbol('proxy headers')
 const kProxyAuth = Symbol('proxy auth')
-const kPool = Symbol('pool')
+const kProxyProtocol = Symbol('proxy protocol')
+const kPools = Symbol('pools')
 const kConnector = Symbol('connector')
+const kRequestTls = Symbol('request tls settings')
 
 // Static flag to ensure warning is only emitted once per process
 let experimentalWarningEmitted = false
@@ -23208,6 +23436,8 @@ class Socks5ProxyAgent extends DispatcherBase {
 
     this[kProxyUrl] = url
     this[kProxyHeaders] = options.headers || {}
+    this[kProxyProtocol] = options.proxyTls ? 'https:' : 'http:'
+    this[kRequestTls] = options.requestTls
 
     // Extract auth from URL or options
     this[kProxyAuth] = {
@@ -23221,8 +23451,8 @@ class Socks5ProxyAgent extends DispatcherBase {
       servername: options.proxyTls?.servername || url.hostname
     })
 
-    // Pool for the actual HTTP connections (with SOCKS5 tunnel connect function)
-    this[kPool] = null
+    // Pools for the actual HTTP connections (with SOCKS5 tunnel connect function), keyed by origin
+    this[kPools] = new Map()
   }
 
   /**
@@ -23236,23 +23466,18 @@ class Socks5ProxyAgent extends DispatcherBase {
 
     // Connect to the SOCKS5 proxy
     const socket = await new Promise((resolve, reject) => {
-      const onConnect = () => {
-        socket.removeListener('error', onError)
-        resolve(socket)
-      }
-
-      const onError = (err) => {
-        socket.removeListener('connect', onConnect)
-        reject(err)
-      }
-
-      const socket = net.connect({
+      this[kConnector]({
+        hostname: proxyHost,
         host: proxyHost,
-        port: proxyPort
+        port: proxyPort,
+        protocol: this[kProxyProtocol]
+      }, (err, socket) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(socket)
+        }
       })
-
-      socket.once('connect', onConnect)
-      socket.once('error', onError)
     })
 
     // Create SOCKS5 client
@@ -23286,7 +23511,7 @@ class Socks5ProxyAgent extends DispatcherBase {
       }
 
       // Check if already authenticated (for NO_AUTH method)
-      if (socks5Client.state === 'authenticated') {
+      if (socks5Client.state === STATES.AUTHENTICATED) {
         clearTimeout(timeout)
         resolve()
       } else {
@@ -23327,15 +23552,17 @@ class Socks5ProxyAgent extends DispatcherBase {
   /**
    * Dispatch a request through the SOCKS5 proxy
    */
-  async [kDispatch] (opts, handler) {
+  [kDispatch] (opts, handler) {
     const { origin } = opts
 
     debug('dispatching request to', origin, 'via SOCKS5')
 
     try {
-      // Create Pool with custom connect function if we don't have one yet
-      if (!this[kPool] || this[kPool].destroyed || this[kPool].closed) {
-        this[kPool] = new Pool(origin, {
+      const originKey = String(origin)
+      let pool = this[kPools].get(originKey)
+      // Create a Pool per origin so requests are not routed to the wrong host
+      if (!pool || pool.destroyed || pool.closed) {
+        pool = new Pool(origin, {
           pipelining: opts.pipelining,
           connections: opts.connections,
           connect: async (connectOpts, callback) => {
@@ -23357,9 +23584,9 @@ class Socks5ProxyAgent extends DispatcherBase {
                 }
                 debug('upgrading to TLS')
                 finalSocket = tls.connect({
+                  ...this[kRequestTls],
                   socket,
-                  servername: targetHost,
-                  ...connectOpts.tls || {}
+                  servername: this[kRequestTls]?.servername || targetHost
                 })
 
                 await new Promise((resolve, reject) => {
@@ -23375,14 +23602,19 @@ class Socks5ProxyAgent extends DispatcherBase {
             }
           }
         })
+        this[kPools].set(originKey, pool)
       }
 
-      // Dispatch the request through the pool
-      return this[kPool][kDispatch](opts, handler)
+      // Dispatch the request through the per-origin pool
+      return pool[kDispatch](opts, handler)
     } catch (err) {
       debug('dispatch error:', err)
-      if (typeof handler.onError === 'function') {
+      if (typeof handler.onResponseError === 'function') {
+        handler.onResponseError(null, err)
+        return false
+      } else if (typeof handler.onError === 'function') {
         handler.onError(err)
+        return false
       } else {
         throw err
       }
@@ -23390,15 +23622,21 @@ class Socks5ProxyAgent extends DispatcherBase {
   }
 
   async [kClose] () {
-    if (this[kPool]) {
-      await this[kPool].close()
+    const closePromises = []
+    for (const pool of this[kPools].values()) {
+      closePromises.push(pool.close())
     }
+    this[kPools].clear()
+    await Promise.all(closePromises)
   }
 
   async [kDestroy] (err) {
-    if (this[kPool]) {
-      await this[kPool].destroy(err)
+    const destroyPromises = []
+    for (const pool of this[kPools].values()) {
+      destroyPromises.push(pool.destroy(err))
     }
+    this[kPools].clear()
+    await Promise.all(destroyPromises)
   }
 }
 
@@ -23407,7 +23645,7 @@ module.exports = Socks5ProxyAgent
 
 /***/ }),
 
-/***/ 311:
+/***/ 2783:
 /***/ ((module) => {
 
 
@@ -23447,16 +23685,17 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8598:
+/***/ 6798:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 // We include a version number for the Dispatcher API. In case of breaking changes,
 // this version number must be increased to avoid conflicts.
-const globalDispatcher = Symbol.for('undici.globalDispatcher.1')
-const { InvalidArgumentError } = __nccwpck_require__(8450)
-const Agent = __nccwpck_require__(2542)
+const globalDispatcher = Symbol.for('undici.globalDispatcher.2')
+const legacyGlobalDispatcher = Symbol.for('undici.globalDispatcher.1')
+const { InvalidArgumentError } = __nccwpck_require__(9370)
+const Agent = __nccwpck_require__(4742)
 
 if (getGlobalDispatcher() === undefined) {
   setGlobalDispatcher(new Agent())
@@ -23466,7 +23705,15 @@ function setGlobalDispatcher (agent) {
   if (!agent || typeof agent.dispatch !== 'function') {
     throw new InvalidArgumentError('Argument agent must implement Agent')
   }
+
   Object.defineProperty(globalThis, globalDispatcher, {
+    value: agent,
+    writable: true,
+    enumerable: false,
+    configurable: false
+  })
+
+  Object.defineProperty(globalThis, legacyGlobalDispatcher, {
     value: agent,
     writable: true,
     enumerable: false,
@@ -23475,7 +23722,7 @@ function setGlobalDispatcher (agent) {
 }
 
 function getGlobalDispatcher () {
-  return globalThis[globalDispatcher]
+  return globalThis[legacyGlobalDispatcher]
 }
 
 // These are the globals that can be installed by undici.install().
@@ -23504,18 +23751,18 @@ module.exports = {
 
 /***/ }),
 
-/***/ 941:
+/***/ 1909:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const util = __nccwpck_require__(9741)
+const util = __nccwpck_require__(6469)
 const {
   parseCacheControlHeader,
   parseVaryHeader,
   isEtagUsable
-} = __nccwpck_require__(8956)
-const { parseHttpDate } = __nccwpck_require__(8148)
+} = __nccwpck_require__(8772)
+const { parseHttpDate } = __nccwpck_require__(5628)
 
 function noop () {}
 
@@ -23644,7 +23891,7 @@ class CacheHandler {
     }
 
     const cacheControlDirectives = cacheControlHeader ? parseCacheControlHeader(cacheControlHeader) : {}
-    if (!canCacheResponse(this.#cacheType, statusCode, resHeaders, cacheControlDirectives)) {
+    if (!canCacheResponse(this.#cacheType, statusCode, resHeaders, cacheControlDirectives, this.#cacheKey.headers)) {
       return downstreamOnHeaders()
     }
 
@@ -23849,8 +24096,9 @@ class CacheHandler {
  * @param {number} statusCode
  * @param {import('../../types/header.d.ts').IncomingHttpHeaders} resHeaders
  * @param {import('../../types/cache-interceptor.d.ts').default.CacheControlDirectives} cacheControlDirectives
+ * @param {import('../../types/header.d.ts').IncomingHttpHeaders} [reqHeaders]
  */
-function canCacheResponse (cacheType, statusCode, resHeaders, cacheControlDirectives) {
+function canCacheResponse (cacheType, statusCode, resHeaders, cacheControlDirectives, reqHeaders) {
   // Status code must be final and understood.
   if (statusCode < 200 || NOT_UNDERSTOOD_STATUS_CODES.includes(statusCode)) {
     return false
@@ -23881,8 +24129,16 @@ function canCacheResponse (cacheType, statusCode, resHeaders, cacheControlDirect
   }
 
   // https://www.rfc-editor.org/rfc/rfc9111.html#name-storing-responses-to-authen
-  if (resHeaders.authorization) {
-    if (!cacheControlDirectives.public || typeof resHeaders.authorization !== 'string') {
+  if (reqHeaders?.authorization) {
+    if (
+      !cacheControlDirectives.public &&
+      !cacheControlDirectives['s-maxage'] &&
+      !cacheControlDirectives['must-revalidate']
+    ) {
+      return false
+    }
+
+    if (typeof reqHeaders.authorization !== 'string') {
       return false
     }
 
@@ -24002,8 +24258,16 @@ function determineDeleteAt (now, cacheControlDirectives, staleAt) {
     staleIfError = staleAt + (cacheControlDirectives['stale-if-error'] * 1000)
   }
 
-  if (staleWhileRevalidate === -Infinity && staleIfError === -Infinity) {
+  if (cacheControlDirectives.immutable && staleWhileRevalidate === -Infinity && staleIfError === -Infinity) {
     immutable = now + 31536000000
+  }
+
+  // When no stale directives or immutable flag, add a revalidation buffer
+  // equal to the freshness lifetime so the entry survives past staleAt long
+  // enough to be revalidated instead of silently disappearing.
+  if (staleWhileRevalidate === -Infinity && staleIfError === -Infinity && immutable === -Infinity) {
+    const freshnessLifetime = staleAt - now
+    return staleAt + freshnessLifetime
   }
 
   return Math.max(staleAt, staleWhileRevalidate, staleIfError, immutable)
@@ -24072,7 +24336,7 @@ module.exports = CacheHandler
 
 /***/ }),
 
-/***/ 8226:
+/***/ 5178:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -24203,13 +24467,13 @@ module.exports = CacheRevalidationHandler
 
 /***/ }),
 
-/***/ 1794:
+/***/ 6586:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const assert = __nccwpck_require__(4589)
-const WrapHandler = __nccwpck_require__(633)
+const WrapHandler = __nccwpck_require__(7873)
 
 /**
  * @deprecated
@@ -24277,12 +24541,12 @@ module.exports = class DecoratorHandler {
 
 /***/ }),
 
-/***/ 9406:
+/***/ 1798:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { RequestAbortedError } = __nccwpck_require__(8450)
+const { RequestAbortedError } = __nccwpck_require__(9370)
 
 /**
  * @typedef {import('../../types/dispatcher.d.ts').default.DispatchHandler} DispatchHandler
@@ -24744,15 +25008,15 @@ module.exports = DeduplicationHandler
 
 /***/ }),
 
-/***/ 825:
+/***/ 2737:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const util = __nccwpck_require__(9741)
-const { kBodyUsed } = __nccwpck_require__(836)
+const util = __nccwpck_require__(6469)
+const { kBodyUsed } = __nccwpck_require__(3916)
 const assert = __nccwpck_require__(4589)
-const { InvalidArgumentError } = __nccwpck_require__(8450)
+const { InvalidArgumentError } = __nccwpck_require__(9370)
 const EE = __nccwpck_require__(8474)
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
@@ -24989,20 +25253,20 @@ module.exports = RedirectHandler
 
 /***/ }),
 
-/***/ 4801:
+/***/ 953:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 const assert = __nccwpck_require__(4589)
 
-const { kRetryHandlerDefaultRetry } = __nccwpck_require__(836)
-const { RequestRetryError } = __nccwpck_require__(8450)
-const WrapHandler = __nccwpck_require__(633)
+const { kRetryHandlerDefaultRetry } = __nccwpck_require__(3916)
+const { RequestRetryError } = __nccwpck_require__(9370)
+const WrapHandler = __nccwpck_require__(7873)
 const {
   isDisturbed,
   parseRangeHeader,
   wrapRequestBody
-} = __nccwpck_require__(9741)
+} = __nccwpck_require__(6469)
 
 function calculateRetryAfterHeader (retryAfter) {
   const retryTime = new Date(retryAfter).getTime()
@@ -25390,13 +25654,13 @@ module.exports = RetryHandler
 
 /***/ }),
 
-/***/ 2926:
+/***/ 7974:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { parseHeaders } = __nccwpck_require__(9741)
-const { InvalidArgumentError } = __nccwpck_require__(8450)
+const { parseHeaders } = __nccwpck_require__(6469)
+const { InvalidArgumentError } = __nccwpck_require__(9370)
 
 const kResume = Symbol('resume')
 
@@ -25407,6 +25671,9 @@ class UnwrapController {
   #abort
 
   [kResume] = null
+
+  rawHeaders = null
+  rawTrailers = null
 
   constructor (abort) {
     this.#abort = abort
@@ -25467,11 +25734,13 @@ module.exports = class UnwrapHandler {
   }
 
   onUpgrade (statusCode, rawHeaders, socket) {
+    this.#controller.rawHeaders = rawHeaders
     this.#handler.onRequestUpgrade?.(this.#controller, statusCode, parseHeaders(rawHeaders), socket)
   }
 
   onHeaders (statusCode, rawHeaders, resume, statusMessage) {
     this.#controller[kResume] = resume
+    this.#controller.rawHeaders = rawHeaders
     this.#handler.onResponseStart?.(this.#controller, statusCode, parseHeaders(rawHeaders), statusMessage)
     return !this.#controller.paused
   }
@@ -25482,6 +25751,7 @@ module.exports = class UnwrapHandler {
   }
 
   onComplete (rawTrailers) {
+    this.#controller.rawTrailers = rawTrailers
     this.#handler.onResponseEnd?.(this.#controller, parseHeaders(rawTrailers))
   }
 
@@ -25497,12 +25767,12 @@ module.exports = class UnwrapHandler {
 
 /***/ }),
 
-/***/ 633:
+/***/ 7873:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { InvalidArgumentError } = __nccwpck_require__(8450)
+const { InvalidArgumentError } = __nccwpck_require__(9370)
 
 module.exports = class WrapHandler {
   #handler
@@ -25609,19 +25879,19 @@ function toRawHeaderValue (value) {
 
 /***/ }),
 
-/***/ 6555:
+/***/ 6291:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const assert = __nccwpck_require__(4589)
 const { Readable } = __nccwpck_require__(7075)
-const util = __nccwpck_require__(9741)
-const CacheHandler = __nccwpck_require__(941)
-const MemoryCacheStore = __nccwpck_require__(9726)
-const CacheRevalidationHandler = __nccwpck_require__(8226)
-const { assertCacheStore, assertCacheMethods, makeCacheKey, normalizeHeaders, parseCacheControlHeader } = __nccwpck_require__(8956)
-const { AbortError } = __nccwpck_require__(8450)
+const util = __nccwpck_require__(6469)
+const CacheHandler = __nccwpck_require__(1909)
+const MemoryCacheStore = __nccwpck_require__(6518)
+const CacheRevalidationHandler = __nccwpck_require__(5178)
+const { assertCacheStore, assertCacheMethods, makeCacheKey, normalizeHeaders, parseCacheControlHeader } = __nccwpck_require__(8772)
+const { AbortError } = __nccwpck_require__(9370)
 
 /**
  * @param {(string | RegExp)[] | undefined} origins
@@ -26111,15 +26381,15 @@ module.exports = (opts = {}) => {
 
 /***/ }),
 
-/***/ 4826:
+/***/ 2818:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const { createInflate, createGunzip, createBrotliDecompress, createZstdDecompress } = __nccwpck_require__(8522)
 const { pipeline } = __nccwpck_require__(7075)
-const DecoratorHandler = __nccwpck_require__(1794)
-const { runtimeFeatures } = __nccwpck_require__(7564)
+const DecoratorHandler = __nccwpck_require__(6586)
+const { runtimeFeatures } = __nccwpck_require__(340)
 
 /** @typedef {import('node:stream').Transform} Transform */
 /** @typedef {import('node:stream').Transform} Controller */
@@ -26377,15 +26647,15 @@ module.exports = createDecompressInterceptor
 
 /***/ }),
 
-/***/ 4733:
+/***/ 805:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const diagnosticsChannel = __nccwpck_require__(3053)
-const util = __nccwpck_require__(9741)
-const DeduplicationHandler = __nccwpck_require__(9406)
-const { normalizeHeaders, makeCacheKey, makeDeduplicationKey } = __nccwpck_require__(8956)
+const util = __nccwpck_require__(6469)
+const DeduplicationHandler = __nccwpck_require__(1798)
+const { normalizeHeaders, makeCacheKey, makeDeduplicationKey } = __nccwpck_require__(8772)
 
 const pendingRequestsChannel = diagnosticsChannel.channel('undici:request:pending-requests')
 
@@ -26501,14 +26771,14 @@ module.exports = (opts = {}) => {
 
 /***/ }),
 
-/***/ 6978:
+/***/ 7066:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 const { isIP } = __nccwpck_require__(7030)
 const { lookup } = __nccwpck_require__(610)
-const DecoratorHandler = __nccwpck_require__(1794)
-const { InvalidArgumentError, InformationalError } = __nccwpck_require__(8450)
+const DecoratorHandler = __nccwpck_require__(6586)
+const { InvalidArgumentError, InformationalError } = __nccwpck_require__(9370)
 const maxInt = Math.pow(2, 31) - 1
 
 function hasSafeIterator (headers) {
@@ -27079,13 +27349,13 @@ module.exports = interceptorOpts => {
 
 /***/ }),
 
-/***/ 9427:
+/***/ 5995:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(8450)
-const DecoratorHandler = __nccwpck_require__(1794)
+const { InvalidArgumentError, RequestAbortedError } = __nccwpck_require__(9370)
+const DecoratorHandler = __nccwpck_require__(6586)
 
 class DumpHandler extends DecoratorHandler {
   #maxSize = 1024 * 1024
@@ -27198,12 +27468,12 @@ module.exports = createDumpInterceptor
 
 /***/ }),
 
-/***/ 1981:
+/***/ 1861:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const RedirectHandler = __nccwpck_require__(825)
+const RedirectHandler = __nccwpck_require__(2737)
 
 function createRedirectInterceptor ({ maxRedirections: defaultMaxRedirections } = {}) {
   return (dispatch) => {
@@ -27226,14 +27496,14 @@ module.exports = createRedirectInterceptor
 
 /***/ }),
 
-/***/ 6357:
+/***/ 5037:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 // const { parseHeaders } = require('../core/util')
-const DecoratorHandler = __nccwpck_require__(1794)
-const { ResponseError } = __nccwpck_require__(8450)
+const DecoratorHandler = __nccwpck_require__(6586)
+const { ResponseError } = __nccwpck_require__(9370)
 
 class ResponseErrorHandler extends DecoratorHandler {
   #statusCode
@@ -27328,11 +27598,11 @@ module.exports = () => {
 
 /***/ }),
 
-/***/ 9147:
+/***/ 3939:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
-const RetryHandler = __nccwpck_require__(4801)
+const RetryHandler = __nccwpck_require__(953)
 
 module.exports = globalOpts => {
   return dispatch => {
@@ -27354,13 +27624,13 @@ module.exports = globalOpts => {
 
 /***/ }),
 
-/***/ 9455:
+/***/ 7687:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SPECIAL_HEADERS = exports.MINOR = exports.MAJOR = exports.HTAB_SP_VCHAR_OBS_TEXT = exports.QUOTED_STRING = exports.CONNECTION_TOKEN_CHARS = exports.HEADER_CHARS = exports.TOKEN = exports.HEX = exports.URL_CHAR = exports.USERINFO_CHARS = exports.MARK = exports.ALPHANUM = exports.NUM = exports.HEX_MAP = exports.NUM_MAP = exports.ALPHA = exports.STATUSES_HTTP = exports.H_METHOD_MAP = exports.METHOD_MAP = exports.METHODS_RTSP = exports.METHODS_ICE = exports.METHODS_HTTP = exports.HEADER_STATE = exports.FINISH = exports.STATUSES = exports.METHODS = exports.LENIENT_FLAGS = exports.FLAGS = exports.TYPE = exports.ERROR = void 0;
-const utils_1 = __nccwpck_require__(1599);
+const utils_1 = __nccwpck_require__(7095);
 // Emums
 exports.ERROR = {
     OK: 0,
@@ -27892,7 +28162,7 @@ exports["default"] = {
 
 /***/ }),
 
-/***/ 1721:
+/***/ 1633:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 /* module decorator */ module = __nccwpck_require__.nmd(module);
@@ -27915,7 +28185,7 @@ Object.defineProperty(module, 'exports', {
 
 /***/ }),
 
-/***/ 5867:
+/***/ 3011:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 /* module decorator */ module = __nccwpck_require__.nmd(module);
@@ -27938,7 +28208,7 @@ Object.defineProperty(module, 'exports', {
 
 /***/ }),
 
-/***/ 1599:
+/***/ 7095:
 /***/ ((__unused_webpack_module, exports) => {
 
 
@@ -27957,13 +28227,13 @@ function enumToMap(obj, filter = [], exceptions = []) {
 
 /***/ }),
 
-/***/ 3016:
+/***/ 9328:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { kClients } = __nccwpck_require__(836)
-const Agent = __nccwpck_require__(2542)
+const { kClients } = __nccwpck_require__(3916)
+const Agent = __nccwpck_require__(4742)
 const {
   kAgent,
   kMockAgentSet,
@@ -27981,14 +28251,14 @@ const {
   kMockAgentAcceptsNonStandardSearchParameters,
   kMockCallHistoryAddLog,
   kIgnoreTrailingSlash
-} = __nccwpck_require__(8588)
-const MockClient = __nccwpck_require__(5022)
-const MockPool = __nccwpck_require__(8227)
-const { matchValue, normalizeSearchParams, buildAndValidateMockOptions, normalizeOrigin } = __nccwpck_require__(1984)
-const { InvalidArgumentError, UndiciError } = __nccwpck_require__(8450)
-const Dispatcher = __nccwpck_require__(410)
-const PendingInterceptorsFormatter = __nccwpck_require__(7159)
-const { MockCallHistory } = __nccwpck_require__(4636)
+} = __nccwpck_require__(9476)
+const MockClient = __nccwpck_require__(8854)
+const MockPool = __nccwpck_require__(4187)
+const { matchValue, normalizeSearchParams, buildAndValidateMockOptions, normalizeOrigin } = __nccwpck_require__(6552)
+const { InvalidArgumentError, UndiciError } = __nccwpck_require__(9370)
+const Dispatcher = __nccwpck_require__(6530)
+const PendingInterceptorsFormatter = __nccwpck_require__(4879)
+const { MockCallHistory } = __nccwpck_require__(9876)
 
 class MockAgent extends Dispatcher {
   constructor (opts = {}) {
@@ -28196,22 +28466,22 @@ module.exports = MockAgent
 
 /***/ }),
 
-/***/ 4636:
+/***/ 9876:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { kMockCallHistoryAddLog } = __nccwpck_require__(8588)
-const { InvalidArgumentError } = __nccwpck_require__(8450)
+const { kMockCallHistoryAddLog } = __nccwpck_require__(9476)
+const { InvalidArgumentError } = __nccwpck_require__(9370)
 
-function handleFilterCallsWithOptions (criteria, options, handler, store) {
+function handleFilterCallsWithOptions (criteria, options, handler, store, allLogs) {
   switch (options.operator) {
     case 'OR':
-      store.push(...handler(criteria))
+      store.push(...handler(criteria, allLogs))
 
       return store
     case 'AND':
-      return handler.call({ logs: store }, criteria)
+      return handler(criteria, store)
     default:
       // guard -- should never happens because buildAndValidateFilterCallsOptions is called before
       throw new InvalidArgumentError('options.operator must to be a case insensitive string equal to \'OR\' or \'AND\'')
@@ -28236,14 +28506,14 @@ function buildAndValidateFilterCallsOptions (options = {}) {
 }
 
 function makeFilterCalls (parameterName) {
-  return (parameterValue) => {
+  return (parameterValue, logs) => {
     if (typeof parameterValue === 'string' || parameterValue == null) {
-      return this.logs.filter((log) => {
+      return logs.filter((log) => {
         return log[parameterName] === parameterValue
       })
     }
     if (parameterValue instanceof RegExp) {
-      return this.logs.filter((log) => {
+      return logs.filter((log) => {
         return parameterValue.test(log[parameterName])
       })
     }
@@ -28376,30 +28646,30 @@ class MockCallHistory {
 
       const finalOptions = { operator: 'OR', ...buildAndValidateFilterCallsOptions(options) }
 
-      let maybeDuplicatedLogsFiltered = []
+      let maybeDuplicatedLogsFiltered = finalOptions.operator === 'AND' ? this.logs : []
       if ('protocol' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.protocol, finalOptions, this.filterCallsByProtocol, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.protocol, finalOptions, this.filterCallsByProtocol, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('host' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.host, finalOptions, this.filterCallsByHost, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.host, finalOptions, this.filterCallsByHost, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('port' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.port, finalOptions, this.filterCallsByPort, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.port, finalOptions, this.filterCallsByPort, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('origin' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.origin, finalOptions, this.filterCallsByOrigin, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.origin, finalOptions, this.filterCallsByOrigin, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('path' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.path, finalOptions, this.filterCallsByPath, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.path, finalOptions, this.filterCallsByPath, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('hash' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.hash, finalOptions, this.filterCallsByHash, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.hash, finalOptions, this.filterCallsByHash, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('fullUrl' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.fullUrl, finalOptions, this.filterCallsByFullUrl, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.fullUrl, finalOptions, this.filterCallsByFullUrl, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('method' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.method, finalOptions, this.filterCallsByMethod, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.method, finalOptions, this.filterCallsByMethod, maybeDuplicatedLogsFiltered, this.logs)
       }
 
       const uniqLogsFiltered = [...new Set(maybeDuplicatedLogsFiltered)]
@@ -28451,14 +28721,14 @@ module.exports.MockCallHistoryLog = MockCallHistoryLog
 
 /***/ }),
 
-/***/ 5022:
+/***/ 8854:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const { promisify } = __nccwpck_require__(7975)
-const Client = __nccwpck_require__(5856)
-const { buildMockDispatch } = __nccwpck_require__(1984)
+const Client = __nccwpck_require__(9448)
+const { buildMockDispatch } = __nccwpck_require__(6552)
 const {
   kDispatches,
   kMockAgent,
@@ -28468,10 +28738,10 @@ const {
   kOriginalDispatch,
   kConnected,
   kIgnoreTrailingSlash
-} = __nccwpck_require__(8588)
-const { MockInterceptor } = __nccwpck_require__(2626)
-const Symbols = __nccwpck_require__(836)
-const { InvalidArgumentError } = __nccwpck_require__(8450)
+} = __nccwpck_require__(9476)
+const { MockInterceptor } = __nccwpck_require__(2554)
+const Symbols = __nccwpck_require__(3916)
+const { InvalidArgumentError } = __nccwpck_require__(9370)
 
 /**
  * MockClient provides an API that extends the Client to influence the mockDispatches.
@@ -28526,12 +28796,12 @@ module.exports = MockClient
 
 /***/ }),
 
-/***/ 1242:
+/***/ 9029:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { UndiciError } = __nccwpck_require__(8450)
+const { UndiciError } = __nccwpck_require__(9370)
 
 const kMockNotMatchedError = Symbol.for('undici.error.UND_MOCK_ERR_MOCK_NOT_MATCHED')
 
@@ -28562,12 +28832,12 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2626:
+/***/ 2554:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { getResponseData, buildKey, addMockDispatch } = __nccwpck_require__(1984)
+const { getResponseData, buildKey, addMockDispatch } = __nccwpck_require__(6552)
 const {
   kDispatches,
   kDispatchKey,
@@ -28576,9 +28846,9 @@ const {
   kContentLength,
   kMockDispatch,
   kIgnoreTrailingSlash
-} = __nccwpck_require__(8588)
-const { InvalidArgumentError } = __nccwpck_require__(8450)
-const { serializePathWithQuery } = __nccwpck_require__(9741)
+} = __nccwpck_require__(9476)
+const { InvalidArgumentError } = __nccwpck_require__(9370)
+const { serializePathWithQuery } = __nccwpck_require__(6469)
 
 /**
  * Defines the scope API for an interceptor reply
@@ -28778,14 +29048,14 @@ module.exports.MockScope = MockScope
 
 /***/ }),
 
-/***/ 8227:
+/***/ 4187:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const { promisify } = __nccwpck_require__(7975)
-const Pool = __nccwpck_require__(1037)
-const { buildMockDispatch } = __nccwpck_require__(1984)
+const Pool = __nccwpck_require__(8261)
+const { buildMockDispatch } = __nccwpck_require__(6552)
 const {
   kDispatches,
   kMockAgent,
@@ -28795,10 +29065,10 @@ const {
   kOriginalDispatch,
   kConnected,
   kIgnoreTrailingSlash
-} = __nccwpck_require__(8588)
-const { MockInterceptor } = __nccwpck_require__(2626)
-const Symbols = __nccwpck_require__(836)
-const { InvalidArgumentError } = __nccwpck_require__(8450)
+} = __nccwpck_require__(9476)
+const { MockInterceptor } = __nccwpck_require__(2554)
+const Symbols = __nccwpck_require__(3916)
+const { InvalidArgumentError } = __nccwpck_require__(9370)
 
 /**
  * MockPool provides an API that extends the Pool to influence the mockDispatches.
@@ -28853,7 +29123,7 @@ module.exports = MockPool
 
 /***/ }),
 
-/***/ 8588:
+/***/ 9476:
 /***/ ((module) => {
 
 
@@ -28885,33 +29155,35 @@ module.exports = {
   kMockAgentAddCallHistoryLog: Symbol('mock agent add call history log'),
   kMockAgentIsCallHistoryEnabled: Symbol('mock agent is call history enabled'),
   kMockAgentAcceptsNonStandardSearchParameters: Symbol('mock agent accepts non standard search parameters'),
-  kMockCallHistoryAddLog: Symbol('mock call history add log')
+  kMockCallHistoryAddLog: Symbol('mock call history add log'),
+  kTotalDispatchCount: Symbol('total dispatch count')
 }
 
 
 /***/ }),
 
-/***/ 1984:
+/***/ 6552:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { MockNotMatchedError } = __nccwpck_require__(1242)
+const { MockNotMatchedError } = __nccwpck_require__(9029)
 const {
   kDispatches,
   kMockAgent,
   kOriginalDispatch,
   kOrigin,
-  kGetNetConnect
-} = __nccwpck_require__(8588)
-const { serializePathWithQuery } = __nccwpck_require__(9741)
+  kGetNetConnect,
+  kTotalDispatchCount
+} = __nccwpck_require__(9476)
+const { serializePathWithQuery } = __nccwpck_require__(6469)
 const { STATUS_CODES } = __nccwpck_require__(7067)
 const {
   types: {
     isPromise
   }
 } = __nccwpck_require__(7975)
-const { InvalidArgumentError } = __nccwpck_require__(8450)
+const { InvalidArgumentError } = __nccwpck_require__(9370)
 
 function matchValue (match, value) {
   if (typeof match === 'string') {
@@ -29102,6 +29374,8 @@ function addMockDispatch (mockDispatches, key, data, opts) {
   const replyData = typeof data === 'function' ? { callback: data } : { ...data }
   const newMockDispatch = { ...baseData, ...key, pending: true, data: { error: null, ...replyData } }
   mockDispatches.push(newMockDispatch)
+  // Track total number of intercepts ever registered for better error messages
+  mockDispatches[kTotalDispatchCount] = (mockDispatches[kTotalDispatchCount] || 0) + 1
   return newMockDispatch
 }
 
@@ -29297,13 +29571,16 @@ function buildMockDispatch () {
       } catch (error) {
         if (error.code === 'UND_MOCK_ERR_MOCK_NOT_MATCHED') {
           const netConnect = agent[kGetNetConnect]()
+          const totalInterceptsCount = this[kDispatches][kTotalDispatchCount] || this[kDispatches].length
+          const pendingInterceptsCount = this[kDispatches].filter(({ consumed }) => !consumed).length
+          const interceptsMessage = `, ${pendingInterceptsCount} interceptor(s) remaining out of ${totalInterceptsCount} defined`
           if (netConnect === false) {
-            throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)`)
+            throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)${interceptsMessage}`)
           }
           if (checkNetConnect(netConnect, origin)) {
             originalDispatch.call(this, opts, handler)
           } else {
-            throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)`)
+            throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)${interceptsMessage}`)
           }
         } else {
           throw error
@@ -29378,7 +29655,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7159:
+/***/ 4879:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -29428,17 +29705,17 @@ module.exports = class PendingInterceptorsFormatter {
 
 /***/ }),
 
-/***/ 5758:
+/***/ 3430:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const Agent = __nccwpck_require__(2542)
-const MockAgent = __nccwpck_require__(3016)
-const { SnapshotRecorder } = __nccwpck_require__(181)
-const WrapHandler = __nccwpck_require__(633)
-const { InvalidArgumentError, UndiciError } = __nccwpck_require__(8450)
-const { validateSnapshotMode } = __nccwpck_require__(6450)
+const Agent = __nccwpck_require__(4742)
+const MockAgent = __nccwpck_require__(9328)
+const { SnapshotRecorder } = __nccwpck_require__(45)
+const WrapHandler = __nccwpck_require__(7873)
+const { InvalidArgumentError, UndiciError } = __nccwpck_require__(9370)
+const { validateSnapshotMode } = __nccwpck_require__(4490)
 
 const kSnapshotRecorder = Symbol('kSnapshotRecorder')
 const kSnapshotMode = Symbol('kSnapshotMode')
@@ -29788,7 +30065,7 @@ module.exports = SnapshotAgent
 
 /***/ }),
 
-/***/ 181:
+/***/ 45:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -29796,8 +30073,8 @@ module.exports = SnapshotAgent
 const { writeFile, readFile, mkdir } = __nccwpck_require__(1455)
 const { dirname, resolve } = __nccwpck_require__(6760)
 const { setTimeout, clearTimeout } = __nccwpck_require__(7997)
-const { InvalidArgumentError, UndiciError } = __nccwpck_require__(8450)
-const { hashId, isUrlExcludedFactory, normalizeHeaders, createHeaderFilters } = __nccwpck_require__(6450)
+const { InvalidArgumentError, UndiciError } = __nccwpck_require__(9370)
+const { hashId, isUrlExcludedFactory, normalizeHeaders, createHeaderFilters } = __nccwpck_require__(4490)
 
 /**
  * @typedef {Object} SnapshotRequestOptions
@@ -30383,13 +30660,13 @@ module.exports = { SnapshotRecorder, formatRequestKey, createRequestHash, filter
 
 /***/ }),
 
-/***/ 6450:
+/***/ 4490:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { InvalidArgumentError } = __nccwpck_require__(8450)
-const { runtimeFeatures } = __nccwpck_require__(7564)
+const { InvalidArgumentError } = __nccwpck_require__(9370)
+const { runtimeFeatures } = __nccwpck_require__(340)
 
 /**
  * @typedef {Object} HeaderFilters
@@ -30548,7 +30825,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8956:
+/***/ 8772:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -30557,9 +30834,9 @@ const {
   safeHTTPMethods,
   pathHasQueryOrFragment,
   hasSafeIterator
-} = __nccwpck_require__(9741)
+} = __nccwpck_require__(6469)
 
-const { serializePathWithQuery } = __nccwpck_require__(9741)
+const { serializePathWithQuery } = __nccwpck_require__(6469)
 
 /**
  * @param {import('../../types/dispatcher.d.ts').default.DispatchOptions} opts
@@ -30571,7 +30848,7 @@ function makeCacheKey (opts) {
 
   let fullPath = opts.path || '/'
 
-  if (opts.query && !pathHasQueryOrFragment(opts.path)) {
+  if (opts.query && !pathHasQueryOrFragment(fullPath)) {
     fullPath = serializePathWithQuery(fullPath, opts.query)
   }
 
@@ -30781,6 +31058,10 @@ function parseCacheControlHeader (header) {
                 headers[headers.length - 1] = lastHeader
               }
 
+              for (let j = 0; j < headers.length; j++) {
+                headers[j] = headers[j].trim()
+              }
+
               if (key in output) {
                 output[key] = output[key].concat(headers)
               } else {
@@ -30789,10 +31070,12 @@ function parseCacheControlHeader (header) {
             }
           } else {
             // Something like `no-cache="some-header"`
+            const fieldName = value.trim()
+
             if (key in output) {
-              output[key] = output[key].concat(value)
+              output[key] = output[key].concat(fieldName)
             } else {
-              output[key] = [value]
+              output[key] = [fieldName]
             }
           }
 
@@ -30927,9 +31210,11 @@ function assertCacheMethods (methods, name = 'CacheMethods') {
  * @returns {string}
  */
 function makeDeduplicationKey (cacheKey, excludeHeaders) {
-  // Create a deterministic string key from the cache key
-  // Include origin, method, path, and sorted headers
-  let key = `${cacheKey.origin}:${cacheKey.method}:${cacheKey.path}`
+  // Use JSON.stringify to produce a collision-resistant key.
+  // Previous format used `:` and `=` delimiters without escaping, which
+  // allowed different header sets to produce identical keys (e.g.
+  // {a:"x:b=y"} vs {a:"x", b:"y"}). See: https://github.com/nodejs/undici/issues/5012
+  const headers = {}
 
   if (cacheKey.headers) {
     const sortedHeaders = Object.keys(cacheKey.headers).sort()
@@ -30938,12 +31223,11 @@ function makeDeduplicationKey (cacheKey, excludeHeaders) {
       if (excludeHeaders?.has(header.toLowerCase())) {
         continue
       }
-      const value = cacheKey.headers[header]
-      key += `:${header}=${Array.isArray(value) ? value.join(',') : value}`
+      headers[header] = cacheKey.headers[header]
     }
   }
 
-  return key
+  return JSON.stringify([cacheKey.origin, cacheKey.method, cacheKey.path, headers])
 }
 
 module.exports = {
@@ -30962,7 +31246,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8148:
+/***/ 5628:
 /***/ ((module) => {
 
 
@@ -31622,7 +31906,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3191:
+/***/ 3343:
 /***/ ((module) => {
 
 
@@ -31657,7 +31941,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7564:
+/***/ 340:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -31788,7 +32072,7 @@ module.exports["default"] = instance
 
 /***/ }),
 
-/***/ 4345:
+/***/ 9969:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -31800,7 +32084,7 @@ const {
   kSize,
   kFree,
   kQueued
-} = __nccwpck_require__(836)
+} = __nccwpck_require__(3916)
 
 class ClientStats {
   constructor (client) {
@@ -31827,7 +32111,7 @@ module.exports = { ClientStats, PoolStats }
 
 /***/ }),
 
-/***/ 7130:
+/***/ 8434:
 /***/ ((module) => {
 
 
@@ -32259,22 +32543,22 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6119:
+/***/ 3855:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const assert = __nccwpck_require__(4589)
 
-const { kConstruct } = __nccwpck_require__(836)
-const { urlEquals, getFieldValues } = __nccwpck_require__(5809)
-const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(9741)
-const { webidl } = __nccwpck_require__(8980)
-const { cloneResponse, fromInnerResponse, getResponseState } = __nccwpck_require__(444)
-const { Request, fromInnerRequest, getRequestState } = __nccwpck_require__(1602)
-const { fetching } = __nccwpck_require__(5251)
-const { urlIsHttpHttpsScheme, readAllBytes } = __nccwpck_require__(9691)
-const { createDeferredPromise } = __nccwpck_require__(3191)
+const { kConstruct } = __nccwpck_require__(3916)
+const { urlEquals, getFieldValues } = __nccwpck_require__(1145)
+const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(6469)
+const { webidl } = __nccwpck_require__(28)
+const { cloneResponse, fromInnerResponse, getResponseState } = __nccwpck_require__(3268)
+const { Request, fromInnerRequest, getRequestState } = __nccwpck_require__(7530)
+const { fetching } = __nccwpck_require__(5691)
+const { urlIsHttpHttpsScheme, readAllBytes } = __nccwpck_require__(2675)
+const { createDeferredPromise } = __nccwpck_require__(3343)
 
 /**
  * @see https://w3c.github.io/ServiceWorker/#dfn-cache-batch-operation
@@ -33130,15 +33414,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8378:
+/***/ 7842:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { Cache } = __nccwpck_require__(6119)
-const { webidl } = __nccwpck_require__(8980)
-const { kEnumerableProperty } = __nccwpck_require__(9741)
-const { kConstruct } = __nccwpck_require__(836)
+const { Cache } = __nccwpck_require__(3855)
+const { webidl } = __nccwpck_require__(28)
+const { kEnumerableProperty } = __nccwpck_require__(6469)
+const { kConstruct } = __nccwpck_require__(3916)
 
 class CacheStorage {
   /**
@@ -33289,14 +33573,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5809:
+/***/ 1145:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const assert = __nccwpck_require__(4589)
-const { URLSerializer } = __nccwpck_require__(8847)
-const { isValidHeaderName } = __nccwpck_require__(9691)
+const { URLSerializer } = __nccwpck_require__(7127)
+const { isValidHeaderName } = __nccwpck_require__(2675)
 
 /**
  * @see https://url.spec.whatwg.org/#concept-url-equals
@@ -33341,7 +33625,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5309:
+/***/ 8901:
 /***/ ((module) => {
 
 
@@ -33360,15 +33644,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8520:
+/***/ 1856:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { parseSetCookie } = __nccwpck_require__(2891)
-const { stringify } = __nccwpck_require__(5570)
-const { webidl } = __nccwpck_require__(8980)
-const { Headers } = __nccwpck_require__(6293)
+const { parseSetCookie } = __nccwpck_require__(7603)
+const { stringify } = __nccwpck_require__(9770)
+const { webidl } = __nccwpck_require__(28)
+const { Headers } = __nccwpck_require__(7418)
 
 const brandChecks = webidl.brandCheckMultiple([Headers, globalThis.Headers].filter(Boolean))
 
@@ -33566,16 +33850,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2891:
+/***/ 7603:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { collectASequenceOfCodePointsFast } = __nccwpck_require__(2465)
-const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(5309)
-const { isCTLExcludingHtab } = __nccwpck_require__(5570)
+const { collectASequenceOfCodePointsFast } = __nccwpck_require__(5001)
+const { maxNameValuePairSize, maxAttributeValueSize } = __nccwpck_require__(8901)
+const { isCTLExcludingHtab } = __nccwpck_require__(9770)
 const assert = __nccwpck_require__(4589)
-const { unescape: qsUnescape } = __nccwpck_require__(1792)
 
 /**
  * @description Parses the field-value attributes of a set-cookie header string.
@@ -33653,7 +33936,7 @@ function parseSetCookie (header) {
   // store arbitrary data in a cookie-value SHOULD encode that data, for
   // example, using Base64 [RFC4648].
   return {
-    name, value: qsUnescape(value), ...parseUnparsedAttributes(unparsedAttributes)
+    name, value, ...parseUnparsedAttributes(unparsedAttributes)
   }
 }
 
@@ -33851,32 +34134,25 @@ function parseUnparsedAttributes (unparsedAttributes, cookieAttributeList = {}) 
     // If the attribute-name case-insensitively matches the string
     // "SameSite", the user agent MUST process the cookie-av as follows:
 
-    // 1. Let enforcement be "Default".
-    let enforcement = 'Default'
-
     const attributeValueLowercase = attributeValue.toLowerCase()
-    // 2. If cookie-av's attribute-value is a case-insensitive match for
-    //    "None", set enforcement to "None".
-    if (attributeValueLowercase.includes('none')) {
-      enforcement = 'None'
-    }
 
-    // 3. If cookie-av's attribute-value is a case-insensitive match for
-    //    "Strict", set enforcement to "Strict".
-    if (attributeValueLowercase.includes('strict')) {
-      enforcement = 'Strict'
+    // 1. If cookie-av's attribute-value is a case-insensitive match for
+    //    "None", append an attribute to the cookie-attribute-list with an
+    //    attribute-name of "SameSite" and an attribute-value of "None".
+    if (attributeValueLowercase === 'none') {
+      cookieAttributeList.sameSite = 'None'
+    } else if (attributeValueLowercase === 'strict') {
+      // 2. If cookie-av's attribute-value is a case-insensitive match for
+      //    "Strict", append an attribute to the cookie-attribute-list with
+      //    an attribute-name of "SameSite" and an attribute-value of
+      //    "Strict".
+      cookieAttributeList.sameSite = 'Strict'
+    } else if (attributeValueLowercase === 'lax') {
+      // 3. If cookie-av's attribute-value is a case-insensitive match for
+      //    "Lax", append an attribute to the cookie-attribute-list with an
+      //    attribute-name of "SameSite" and an attribute-value of "Lax".
+      cookieAttributeList.sameSite = 'Lax'
     }
-
-    // 4. If cookie-av's attribute-value is a case-insensitive match for
-    //    "Lax", set enforcement to "Lax".
-    if (attributeValueLowercase.includes('lax')) {
-      enforcement = 'Lax'
-    }
-
-    // 5. Append an attribute to the cookie-attribute-list with an
-    //    attribute-name of "SameSite" and an attribute-value of
-    //    enforcement.
-    cookieAttributeList.sameSite = enforcement
   } else {
     cookieAttributeList.unparsed ??= []
 
@@ -33895,7 +34171,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5570:
+/***/ 9770:
 /***/ ((module) => {
 
 
@@ -34184,12 +34460,12 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4680:
+/***/ 240:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 const { Transform } = __nccwpck_require__(7075)
-const { isASCIINumber, isValidLastEventId } = __nccwpck_require__(8564)
+const { isASCIINumber, isValidLastEventId } = __nccwpck_require__(7820)
 
 /**
  * @type {number[]} BOM
@@ -34590,21 +34866,21 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1123:
+/***/ 1499:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const { pipeline } = __nccwpck_require__(7075)
-const { fetching } = __nccwpck_require__(5251)
-const { makeRequest } = __nccwpck_require__(1602)
-const { webidl } = __nccwpck_require__(8980)
-const { EventSourceStream } = __nccwpck_require__(4680)
-const { parseMIMEType } = __nccwpck_require__(8847)
-const { createFastMessageEvent } = __nccwpck_require__(7063)
-const { isNetworkError } = __nccwpck_require__(444)
-const { kEnumerableProperty } = __nccwpck_require__(9741)
-const { environmentSettingsObject } = __nccwpck_require__(9691)
+const { fetching } = __nccwpck_require__(5691)
+const { makeRequest } = __nccwpck_require__(7530)
+const { webidl } = __nccwpck_require__(28)
+const { EventSourceStream } = __nccwpck_require__(240)
+const { parseMIMEType } = __nccwpck_require__(7127)
+const { createFastMessageEvent } = __nccwpck_require__(6943)
+const { isNetworkError } = __nccwpck_require__(3268)
+const { kEnumerableProperty } = __nccwpck_require__(6469)
+const { environmentSettingsObject } = __nccwpck_require__(2675)
 
 let experimentalWarned = false
 
@@ -35098,7 +35374,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8564:
+/***/ 7820:
 /***/ ((module) => {
 
 
@@ -35134,29 +35410,29 @@ module.exports = {
 
 /***/ }),
 
-/***/ 867:
+/***/ 6075:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const util = __nccwpck_require__(9741)
+const util = __nccwpck_require__(6469)
 const {
   ReadableStreamFrom,
   readableStreamClose,
   fullyReadBody,
   extractMimeType
-} = __nccwpck_require__(9691)
-const { FormData, setFormDataState } = __nccwpck_require__(9097)
-const { webidl } = __nccwpck_require__(8980)
+} = __nccwpck_require__(2675)
+const { FormData, setFormDataState } = __nccwpck_require__(4017)
+const { webidl } = __nccwpck_require__(28)
 const assert = __nccwpck_require__(4589)
 const { isErrored, isDisturbed } = __nccwpck_require__(7075)
 const { isUint8Array } = __nccwpck_require__(3429)
-const { serializeAMimeType } = __nccwpck_require__(8847)
-const { multipartFormDataParser } = __nccwpck_require__(4105)
-const { createDeferredPromise } = __nccwpck_require__(3191)
-const { parseJSONFromBytes } = __nccwpck_require__(2465)
-const { utf8DecodeBytes } = __nccwpck_require__(311)
-const { runtimeFeatures } = __nccwpck_require__(7564)
+const { serializeAMimeType } = __nccwpck_require__(7127)
+const { multipartFormDataParser } = __nccwpck_require__(6401)
+const { createDeferredPromise } = __nccwpck_require__(3343)
+const { parseJSONFromBytes } = __nccwpck_require__(5001)
+const { utf8DecodeBytes } = __nccwpck_require__(2783)
+const { runtimeFeatures } = __nccwpck_require__(340)
 
 const random = runtimeFeatures.has('crypto')
   ? (__nccwpck_require__(7598).randomInt)
@@ -35650,7 +35926,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7350:
+/***/ 6110:
 /***/ ((module) => {
 
 
@@ -35788,13 +36064,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8847:
+/***/ 7127:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const assert = __nccwpck_require__(4589)
-const { forgivingBase64, collectASequenceOfCodePoints, collectASequenceOfCodePointsFast, isomorphicDecode, removeASCIIWhitespace, removeChars } = __nccwpck_require__(2465)
+const { forgivingBase64, collectASequenceOfCodePoints, collectASequenceOfCodePointsFast, isomorphicDecode, removeASCIIWhitespace, removeChars } = __nccwpck_require__(5001)
 
 const encoder = new TextEncoder()
 
@@ -36391,21 +36667,21 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4105:
+/***/ 6401:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { bufferToLowerCasedHeaderName } = __nccwpck_require__(9741)
-const { HTTP_TOKEN_CODEPOINTS } = __nccwpck_require__(8847)
-const { makeEntry } = __nccwpck_require__(9097)
-const { webidl } = __nccwpck_require__(8980)
+const { bufferToLowerCasedHeaderName } = __nccwpck_require__(6469)
+const { HTTP_TOKEN_CODEPOINTS } = __nccwpck_require__(7127)
+const { makeEntry } = __nccwpck_require__(4017)
+const { webidl } = __nccwpck_require__(28)
 const assert = __nccwpck_require__(4589)
-const { isomorphicDecode } = __nccwpck_require__(2465)
-const { utf8DecodeBytes } = __nccwpck_require__(311)
+const { isomorphicDecode } = __nccwpck_require__(5001)
 
 const dd = Buffer.from('--')
 const decoder = new TextDecoder()
+const decoderIgnoreBOM = new TextDecoder('utf-8', { ignoreBOM: true })
 
 /**
  * @param {string} chars
@@ -36584,7 +36860,7 @@ function multipartFormDataParser (input, mimeType) {
       // 5.11. Otherwise:
 
       // 5.11.1. Let value be the UTF-8 decoding without BOM of body.
-      value = utf8DecodeBytes(Buffer.from(body))
+      value = decoderIgnoreBOM.decode(Buffer.from(body))
     }
 
     // 5.12. Assert: name is a scalar value string and value is either a scalar value string or a File object.
@@ -36600,7 +36876,7 @@ function multipartFormDataParser (input, mimeType) {
  * Parses content-disposition attributes (e.g., name="value" or filename*=utf-8''encoded)
  * @param {Buffer} input
  * @param {{ position: number }} position
- * @returns {{ name: string, value: string }}
+ * @returns {{ name: string, value: string, extended: boolean } | null}
  */
 function parseContentDispositionAttribute (input, position) {
   // Skip leading semicolon and whitespace
@@ -36700,7 +36976,7 @@ function parseContentDispositionAttribute (input, position) {
     value = decoder.decode(tokenValue)
   }
 
-  return { name: attrNameStr, value }
+  return { name: attrNameStr, value, extended: isExtended }
 }
 
 /**
@@ -36764,6 +37040,9 @@ function parseMultipartFormDataHeaders (input, position) {
     switch (bufferToLowerCasedHeaderName(headerName)) {
       case 'content-disposition': {
         name = filename = null
+        // Track whether filename was set from the extended (RFC 5987) form so
+        // a subsequent legacy `filename` attribute does not override it.
+        let filenameIsExtended = false
 
         // Collect the disposition type (should be "form-data")
         const dispositionType = collectASequenceOfBytes(
@@ -36779,8 +37058,8 @@ function parseMultipartFormDataHeaders (input, position) {
         // Parse attributes recursively until CRLF
         while (
           position.position < input.length &&
-          input[position.position] !== 0x0d &&
-          input[position.position + 1] !== 0x0a
+          (input[position.position] !== 0x0d ||
+          input[position.position + 1] !== 0x0a)
         ) {
           const attribute = parseContentDispositionAttribute(input, position)
 
@@ -36791,7 +37070,15 @@ function parseMultipartFormDataHeaders (input, position) {
           if (attribute.name === 'name') {
             name = attribute.value
           } else if (attribute.name === 'filename') {
-            filename = attribute.value
+            // Per RFC 5987 §4.1, when both legacy and extended forms of the
+            // same parameter are present, the extended (filename*) form takes
+            // precedence regardless of the order they appear in.
+            if (attribute.extended) {
+              filename = attribute.value
+              filenameIsExtended = true
+            } else if (!filenameIsExtended) {
+              filename = attribute.value
+            }
           }
         }
 
@@ -36844,7 +37131,7 @@ function parseMultipartFormDataHeaders (input, position) {
 
     // 2.9. If position does not point to a sequence of bytes starting with 0x0D 0x0A
     //      (CR LF), return failure. Otherwise, advance position by 2 (past the newline).
-    if (input[position.position] !== 0x0d && input[position.position + 1] !== 0x0a) {
+    if (input[position.position] !== 0x0d || input[position.position + 1] !== 0x0a) {
       throw parsingError('expected CRLF')
     } else {
       position.position += 2
@@ -36973,14 +37260,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9097:
+/***/ 4017:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { iteratorMixin } = __nccwpck_require__(9691)
-const { kEnumerableProperty } = __nccwpck_require__(9741)
-const { webidl } = __nccwpck_require__(8980)
+const { iteratorMixin } = __nccwpck_require__(2675)
+const { kEnumerableProperty } = __nccwpck_require__(6469)
+const { webidl } = __nccwpck_require__(28)
 const nodeUtil = __nccwpck_require__(7975)
 
 // https://xhr.spec.whatwg.org/#formdata
@@ -37239,7 +37526,7 @@ module.exports = { FormData, makeEntry, setFormDataState }
 
 /***/ }),
 
-/***/ 2756:
+/***/ 1564:
 /***/ ((module) => {
 
 
@@ -37286,21 +37573,21 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6293:
+/***/ 7418:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // https://github.com/Ethan-Arrowood/undici-fetch
 
 
 
-const { kConstruct } = __nccwpck_require__(836)
-const { kEnumerableProperty } = __nccwpck_require__(9741)
+const { kConstruct } = __nccwpck_require__(3916)
+const { kEnumerableProperty } = __nccwpck_require__(6469)
 const {
   iteratorMixin,
   isValidHeaderName,
   isValidHeaderValue
-} = __nccwpck_require__(9691)
-const { webidl } = __nccwpck_require__(8980)
+} = __nccwpck_require__(2675)
+const { webidl } = __nccwpck_require__(28)
 const assert = __nccwpck_require__(4589)
 const util = __nccwpck_require__(7975)
 
@@ -38012,7 +38299,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5251:
+/***/ 5691:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // https://github.com/Ethan-Arrowood/undici-fetch
@@ -38026,9 +38313,9 @@ const {
   makeResponse,
   fromInnerResponse,
   getResponseState
-} = __nccwpck_require__(444)
-const { HeadersList } = __nccwpck_require__(6293)
-const { Request, cloneRequest, getRequestDispatcher, getRequestState } = __nccwpck_require__(1602)
+} = __nccwpck_require__(3268)
+const { HeadersList } = __nccwpck_require__(7418)
+const { Request, cloneRequest, getRequestDispatcher, getRequestState } = __nccwpck_require__(7530)
 const zlib = __nccwpck_require__(8522)
 const {
   makePolicyContainer,
@@ -38063,27 +38350,27 @@ const {
   hasAuthenticationEntry,
   includesCredentials,
   isTraversableNavigable
-} = __nccwpck_require__(9691)
+} = __nccwpck_require__(2675)
 const assert = __nccwpck_require__(4589)
-const { safelyExtractBody, extractBody } = __nccwpck_require__(867)
+const { safelyExtractBody, extractBody } = __nccwpck_require__(6075)
 const {
   redirectStatusSet,
   nullBodyStatus,
   safeMethodsSet,
   requestBodyHeader,
   subresourceSet
-} = __nccwpck_require__(7350)
+} = __nccwpck_require__(6110)
 const EE = __nccwpck_require__(8474)
 const { Readable, pipeline, finished, isErrored, isReadable } = __nccwpck_require__(7075)
-const { addAbortListener, bufferToLowerCasedHeaderName } = __nccwpck_require__(9741)
-const { dataURLProcessor, serializeAMimeType, minimizeSupportedMimeType } = __nccwpck_require__(8847)
-const { getGlobalDispatcher } = __nccwpck_require__(8598)
-const { webidl } = __nccwpck_require__(8980)
+const { addAbortListener, bufferToLowerCasedHeaderName } = __nccwpck_require__(6469)
+const { dataURLProcessor, serializeAMimeType, minimizeSupportedMimeType } = __nccwpck_require__(7127)
+const { getGlobalDispatcher } = __nccwpck_require__(6798)
+const { webidl } = __nccwpck_require__(28)
 const { STATUS_CODES } = __nccwpck_require__(7067)
-const { bytesMatch } = __nccwpck_require__(2463)
-const { createDeferredPromise } = __nccwpck_require__(3191)
-const { isomorphicEncode } = __nccwpck_require__(2465)
-const { runtimeFeatures } = __nccwpck_require__(7564)
+const { bytesMatch } = __nccwpck_require__(7543)
+const { createDeferredPromise } = __nccwpck_require__(3343)
+const { isomorphicEncode } = __nccwpck_require__(5001)
+const { runtimeFeatures } = __nccwpck_require__(340)
 
 // Node.js v23.8.0+ and v22.15.0+ supports Zstandard
 const hasZstd = runtimeFeatures.has('zstd')
@@ -39047,7 +39334,7 @@ function fetchFinale (fetchParams, response) {
       let responseStatus = 0
 
       // 7. If fetchParams’s request’s mode is not "navigate" or response’s has-cross-origin-redirects is false:
-      if (fetchParams.request.mode !== 'navigator' || !response.hasCrossOriginRedirects) {
+      if (fetchParams.request.mode !== 'navigate' || !response.hasCrossOriginRedirects) {
         // 1. Set responseStatus to response’s status.
         responseStatus = response.status
 
@@ -39450,7 +39737,10 @@ async function httpNetworkOrCacheFetch (
   //    8. If contentLengthHeaderValue is non-null, then append
   //    `Content-Length`/contentLengthHeaderValue to httpRequest’s header
   //    list.
-  if (contentLengthHeaderValue != null) {
+  if (
+    contentLengthHeaderValue != null &&
+    !httpRequest.headersList.contains('content-length', true)
+  ) {
     httpRequest.headersList.append('content-length', contentLengthHeaderValue, true)
   }
 
@@ -39661,12 +39951,25 @@ async function httpNetworkOrCacheFetch (
   // 14. If response’s status is 401, httpRequest’s response tainting is not "cors",
   //     includeCredentials is true, and request’s traversable for user prompts is
   //     a traversable navigable:
-  if (response.status === 401 && httpRequest.responseTainting !== 'cors' && includeCredentials && isTraversableNavigable(request.traversableForUserPrompts)) {
+  //
+  //     In Node.js there is no traversable navigable to prompt the user, but we
+  //     still need to handle URL-embedded credentials so authentication retries
+  //     for WebSocket handshakes continue to work.
+  if (response.status === 401 && httpRequest.responseTainting !== 'cors' && includeCredentials && (
+    request.useURLCredentials !== undefined ||
+    isTraversableNavigable(request.traversableForUserPrompts)
+  )) {
     // 2. If request’s body is non-null, then:
     if (request.body != null) {
       // 1. If request’s body’s source is null, then return a network error.
       if (request.body.source == null) {
-        return makeNetworkError('expected non-null body source')
+        // Note: In Node.js, this code path should not be reached because
+        // isTraversableNavigable() returns false for non-navigable contexts.
+        // However, we handle it gracefully by returning the response instead of
+        // a network error, as we won't actually retry the request.
+        // This aligns with the Fetch spec discussion in whatwg/fetch#1132,
+        // which allows implementations flexibility when credentials can't be obtained.
+        return response
       }
 
       // 2. Set request’s body to the body of the result of safely extracting
@@ -40204,7 +40507,15 @@ async function httpNetworkFetch (
           const headersList = new HeadersList()
 
           for (let i = 0; i < rawHeaders.length; i += 2) {
-            headersList.append(bufferToLowerCasedHeaderName(rawHeaders[i]), rawHeaders[i + 1].toString('latin1'), true)
+            const nameStr = bufferToLowerCasedHeaderName(rawHeaders[i])
+            const value = rawHeaders[i + 1]
+            if (Array.isArray(value) && !Buffer.isBuffer(rawHeaders[i + 1])) {
+              for (const val of value) {
+                headersList.append(nameStr, val.toString('latin1'), true)
+              }
+            } else {
+              headersList.append(nameStr, value.toString('latin1'), true)
+            }
           }
           const location = headersList.get('location', true)
 
@@ -40373,7 +40684,15 @@ async function httpNetworkFetch (
           const headersList = new HeadersList()
 
           for (let i = 0; i < rawHeaders.length; i += 2) {
-            headersList.append(bufferToLowerCasedHeaderName(rawHeaders[i]), rawHeaders[i + 1].toString('latin1'), true)
+            const nameStr = bufferToLowerCasedHeaderName(rawHeaders[i])
+            const value = rawHeaders[i + 1]
+            if (Array.isArray(value) && !Buffer.isBuffer(rawHeaders[i + 1])) {
+              for (const val of value) {
+                headersList.append(nameStr, val.toString('latin1'), true)
+              }
+            } else {
+              headersList.append(nameStr, value.toString('latin1'), true)
+            }
           }
 
           resolve({
@@ -40400,22 +40719,22 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1602:
+/***/ 7530:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 /* globals AbortController */
 
 
 
-const { extractBody, mixinBody, cloneBody, bodyUnusable } = __nccwpck_require__(867)
-const { Headers, fill: fillHeaders, HeadersList, setHeadersGuard, getHeadersGuard, setHeadersList, getHeadersList } = __nccwpck_require__(6293)
-const util = __nccwpck_require__(9741)
+const { extractBody, mixinBody, cloneBody, bodyUnusable } = __nccwpck_require__(6075)
+const { Headers, fill: fillHeaders, HeadersList, setHeadersGuard, getHeadersGuard, setHeadersList, getHeadersList } = __nccwpck_require__(7418)
+const util = __nccwpck_require__(6469)
 const nodeUtil = __nccwpck_require__(7975)
 const {
   isValidHTTPToken,
   sameOrigin,
   environmentSettingsObject
-} = __nccwpck_require__(9691)
+} = __nccwpck_require__(2675)
 const {
   forbiddenMethodsSet,
   corsSafeListedMethodsSet,
@@ -40425,11 +40744,11 @@ const {
   requestCredentials,
   requestCache,
   requestDuplex
-} = __nccwpck_require__(7350)
+} = __nccwpck_require__(6110)
 const { kEnumerableProperty, normalizedMethodRecordsBase, normalizedMethodRecords } = util
-const { webidl } = __nccwpck_require__(8980)
-const { URLSerializer } = __nccwpck_require__(8847)
-const { kConstruct } = __nccwpck_require__(836)
+const { webidl } = __nccwpck_require__(28)
+const { URLSerializer } = __nccwpck_require__(7127)
+const { kConstruct } = __nccwpck_require__(3916)
 const assert = __nccwpck_require__(4589)
 const { getMaxListeners, setMaxListeners, defaultMaxListeners } = __nccwpck_require__(8474)
 
@@ -41522,14 +41841,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 444:
+/***/ 3268:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { Headers, HeadersList, fill, getHeadersGuard, setHeadersGuard, setHeadersList } = __nccwpck_require__(6293)
-const { extractBody, cloneBody, mixinBody, streamRegistry, bodyUnusable } = __nccwpck_require__(867)
-const util = __nccwpck_require__(9741)
+const { Headers, HeadersList, fill, getHeadersGuard, setHeadersGuard, setHeadersList } = __nccwpck_require__(7418)
+const { extractBody, cloneBody, mixinBody, streamRegistry, bodyUnusable } = __nccwpck_require__(6075)
+const util = __nccwpck_require__(6469)
 const nodeUtil = __nccwpck_require__(7975)
 const { kEnumerableProperty } = util
 const {
@@ -41538,16 +41857,16 @@ const {
   isAborted,
   isErrorLike,
   environmentSettingsObject: relevantRealm
-} = __nccwpck_require__(9691)
+} = __nccwpck_require__(2675)
 const {
   redirectStatusSet,
   nullBodyStatus
-} = __nccwpck_require__(7350)
-const { webidl } = __nccwpck_require__(8980)
-const { URLSerializer } = __nccwpck_require__(8847)
-const { kConstruct } = __nccwpck_require__(836)
+} = __nccwpck_require__(6110)
+const { webidl } = __nccwpck_require__(28)
+const { URLSerializer } = __nccwpck_require__(7127)
+const { kConstruct } = __nccwpck_require__(3916)
 const assert = __nccwpck_require__(4589)
-const { isomorphicEncode, serializeJavascriptValueToJSONString } = __nccwpck_require__(2465)
+const { isomorphicEncode, serializeJavascriptValueToJSONString } = __nccwpck_require__(5001)
 
 const textEncoder = new TextEncoder('utf-8')
 
@@ -42170,22 +42489,22 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9691:
+/***/ 2675:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const { Transform } = __nccwpck_require__(7075)
 const zlib = __nccwpck_require__(8522)
-const { redirectStatusSet, referrerPolicyTokens, badPortsSet } = __nccwpck_require__(7350)
-const { getGlobalOrigin } = __nccwpck_require__(2756)
-const { collectAnHTTPQuotedString, parseMIMEType } = __nccwpck_require__(8847)
+const { redirectStatusSet, referrerPolicyTokens, badPortsSet } = __nccwpck_require__(6110)
+const { getGlobalOrigin } = __nccwpck_require__(1564)
+const { collectAnHTTPQuotedString, parseMIMEType } = __nccwpck_require__(7127)
 const { performance } = __nccwpck_require__(643)
-const { ReadableStreamFrom, isValidHTTPToken, normalizedMethodRecordsBase } = __nccwpck_require__(9741)
+const { ReadableStreamFrom, isValidHTTPToken, normalizedMethodRecordsBase } = __nccwpck_require__(6469)
 const assert = __nccwpck_require__(4589)
 const { isUint8Array } = __nccwpck_require__(3429)
-const { webidl } = __nccwpck_require__(8980)
-const { isomorphicEncode, collectASequenceOfCodePoints, removeChars } = __nccwpck_require__(2465)
+const { webidl } = __nccwpck_require__(28)
+const { isomorphicEncode, collectASequenceOfCodePoints, removeChars } = __nccwpck_require__(5001)
 
 function responseURL (response) {
   // https://fetch.spec.whatwg.org/#responses
@@ -43622,8 +43941,10 @@ function includesCredentials (url) {
  * @param {object|string} navigable
  */
 function isTraversableNavigable (navigable) {
-  // TODO
-  return true
+  // Returns true only if we have an actual traversable navigable object
+  // that can prompt the user for credentials. In Node.js, this will always
+  // be false since there's no Window object or navigable.
+  return navigable != null && navigable !== 'client' && navigable !== 'no-traversable'
 }
 
 class EnvironmentSettingsObjectBase {
@@ -43697,13 +44018,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2465:
+/***/ 5001:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const assert = __nccwpck_require__(4589)
-const { utf8DecodeBytes } = __nccwpck_require__(311)
+const { utf8DecodeBytes } = __nccwpck_require__(2783)
 
 /**
  * @param {(char: string) => boolean} condition
@@ -43933,13 +44254,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2463:
+/***/ 7543:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const assert = __nccwpck_require__(4589)
-const { runtimeFeatures } = __nccwpck_require__(7564)
+const { runtimeFeatures } = __nccwpck_require__(340)
 
 /**
  * @typedef {object} Metadata
@@ -44247,14 +44568,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8980:
+/***/ 28:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const assert = __nccwpck_require__(4589)
 const { types, inspect } = __nccwpck_require__(7975)
-const { runtimeFeatures } = __nccwpck_require__(7564)
+const { runtimeFeatures } = __nccwpck_require__(340)
 
 const UNDEFINED = 1
 const BOOLEAN = 2
@@ -44442,10 +44763,10 @@ webidl.util.ConvertToInt = function (V, bitLength, signedness, flags) {
   } else {
     // 3. Otherwise:
 
-    // 1. Let lowerBound be -2^bitLength − 1.
-    lowerBound = Math.pow(-2, bitLength) - 1
+    // 1. Let lowerBound be -2^(bitLength − 1).
+    lowerBound = -Math.pow(2, bitLength - 1)
 
-    // 2. Let upperBound be 2^bitLength − 1 − 1.
+    // 2. Let upperBound be 2^(bitLength − 1) − 1.
     upperBound = Math.pow(2, bitLength - 1) - 1
   }
 
@@ -44524,9 +44845,9 @@ webidl.util.ConvertToInt = function (V, bitLength, signedness, flags) {
   // 10. Set x to x modulo 2^bitLength.
   x = x % Math.pow(2, bitLength)
 
-  // 11. If signedness is "signed" and x ≥ 2^bitLength − 1,
+  // 11. If signedness is "signed" and x ≥ 2^(bitLength − 1),
   //    then return x − 2^bitLength.
-  if (signedness === 'signed' && x >= Math.pow(2, bitLength) - 1) {
+  if (signedness === 'signed' && x >= Math.pow(2, bitLength - 1)) {
     return x - Math.pow(2, bitLength)
   }
 
@@ -45260,20 +45581,20 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9502:
+/***/ 6534:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { uid, states, sentCloseFrameState, emptyBuffer, opcodes } = __nccwpck_require__(865)
-const { parseExtensions, isClosed, isClosing, isEstablished, isConnecting, validateCloseCodeAndReason } = __nccwpck_require__(4814)
-const { makeRequest } = __nccwpck_require__(1602)
-const { fetching } = __nccwpck_require__(5251)
-const { Headers, getHeadersList } = __nccwpck_require__(6293)
-const { getDecodeSplit } = __nccwpck_require__(9691)
-const { WebsocketFrameSend } = __nccwpck_require__(5949)
+const { uid, states, sentCloseFrameState, emptyBuffer, opcodes } = __nccwpck_require__(1769)
+const { parseExtensions, isClosed, isClosing, isEstablished, isConnecting, validateCloseCodeAndReason } = __nccwpck_require__(4518)
+const { makeRequest } = __nccwpck_require__(7530)
+const { fetching } = __nccwpck_require__(5691)
+const { Headers, getHeadersList } = __nccwpck_require__(7418)
+const { getDecodeSplit } = __nccwpck_require__(2675)
+const { WebsocketFrameSend } = __nccwpck_require__(6373)
 const assert = __nccwpck_require__(4589)
-const { runtimeFeatures } = __nccwpck_require__(7564)
+const { runtimeFeatures } = __nccwpck_require__(340)
 
 const crypto = runtimeFeatures.has('crypto')
   ? __nccwpck_require__(7598)
@@ -45596,7 +45917,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 865:
+/***/ 1769:
 /***/ ((module) => {
 
 
@@ -45729,14 +46050,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7063:
+/***/ 6943:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { webidl } = __nccwpck_require__(8980)
-const { kEnumerableProperty } = __nccwpck_require__(9741)
-const { kConstruct } = __nccwpck_require__(836)
+const { webidl } = __nccwpck_require__(28)
+const { kEnumerableProperty } = __nccwpck_require__(6469)
+const { kConstruct } = __nccwpck_require__(3916)
 
 /**
  * @see https://html.spec.whatwg.org/multipage/comms.html#messageevent
@@ -46067,13 +46388,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5949:
+/***/ 6373:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { runtimeFeatures } = __nccwpck_require__(7564)
-const { maxUnsigned16Bit, opcodes } = __nccwpck_require__(865)
+const { runtimeFeatures } = __nccwpck_require__(340)
+const { maxUnsigned16Bit, opcodes } = __nccwpck_require__(1769)
 
 const BUFFER_SIZE = 8 * 1024
 
@@ -46207,21 +46528,18 @@ module.exports = {
 
 /***/ }),
 
-/***/ 642:
+/***/ 5738:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const { createInflateRaw, Z_DEFAULT_WINDOWBITS } = __nccwpck_require__(8522)
-const { isValidClientWindowBits } = __nccwpck_require__(4814)
-const { MessageSizeExceededError } = __nccwpck_require__(8450)
+const { isValidClientWindowBits } = __nccwpck_require__(4518)
+const { MessageSizeExceededError } = __nccwpck_require__(9370)
 
 const tail = Buffer.from([0x00, 0x00, 0xff, 0xff])
 const kBuffer = Symbol('kBuffer')
 const kLength = Symbol('kLength')
-
-// Default maximum decompressed message size: 4 MB
-const kDefaultMaxDecompressedSize = 4 * 1024 * 1024
 
 class PerMessageDeflate {
   /** @type {import('node:zlib').InflateRaw} */
@@ -46229,31 +46547,29 @@ class PerMessageDeflate {
 
   #options = {}
 
-  /** @type {boolean} */
-  #aborted = false
-
-  /** @type {Function|null} */
-  #currentCallback = null
+  #maxPayloadSize = 0
 
   /**
    * @param {Map<string, string>} extensions
    */
-  constructor (extensions) {
+  constructor (extensions, options) {
     this.#options.serverNoContextTakeover = extensions.has('server_no_context_takeover')
     this.#options.serverMaxWindowBits = extensions.get('server_max_window_bits')
+
+    this.#maxPayloadSize = options.maxPayloadSize
   }
 
+  /**
+   * Decompress a compressed payload.
+   * @param {Buffer} chunk Compressed data
+   * @param {boolean} fin Final fragment flag
+   * @param {Function} callback Callback function
+   */
   decompress (chunk, fin, callback) {
     // An endpoint uses the following algorithm to decompress a message.
     // 1.  Append 4 octets of 0x00 0x00 0xff 0xff to the tail end of the
     //     payload of the message.
     // 2.  Decompress the resulting data using DEFLATE.
-
-    if (this.#aborted) {
-      callback(new MessageSizeExceededError())
-      return
-    }
-
     if (!this.#inflate) {
       let windowBits = Z_DEFAULT_WINDOWBITS
 
@@ -46276,23 +46592,12 @@ class PerMessageDeflate {
       this.#inflate[kLength] = 0
 
       this.#inflate.on('data', (data) => {
-        if (this.#aborted) {
-          return
-        }
-
         this.#inflate[kLength] += data.length
 
-        if (this.#inflate[kLength] > kDefaultMaxDecompressedSize) {
-          this.#aborted = true
+        if (this.#maxPayloadSize > 0 && this.#inflate[kLength] > this.#maxPayloadSize) {
+          callback(new MessageSizeExceededError())
           this.#inflate.removeAllListeners()
-          this.#inflate.destroy()
           this.#inflate = null
-
-          if (this.#currentCallback) {
-            const cb = this.#currentCallback
-            this.#currentCallback = null
-            cb(new MessageSizeExceededError())
-          }
           return
         }
 
@@ -46305,14 +46610,13 @@ class PerMessageDeflate {
       })
     }
 
-    this.#currentCallback = callback
     this.#inflate.write(chunk)
     if (fin) {
       this.#inflate.write(tail)
     }
 
     this.#inflate.flush(() => {
-      if (this.#aborted || !this.#inflate) {
+      if (!this.#inflate) {
         return
       }
 
@@ -46320,7 +46624,6 @@ class PerMessageDeflate {
 
       this.#inflate[kBuffer].length = 0
       this.#inflate[kLength] = 0
-      this.#currentCallback = null
 
       callback(null, full)
     })
@@ -46332,14 +46635,14 @@ module.exports = { PerMessageDeflate }
 
 /***/ }),
 
-/***/ 1611:
+/***/ 6275:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const { Writable } = __nccwpck_require__(7075)
 const assert = __nccwpck_require__(4589)
-const { parserStates, opcodes, states, emptyBuffer, sentCloseFrameState } = __nccwpck_require__(865)
+const { parserStates, opcodes, states, emptyBuffer, sentCloseFrameState } = __nccwpck_require__(1769)
 const {
   isValidStatusCode,
   isValidOpcode,
@@ -46348,11 +46651,11 @@ const {
   isControlFrame,
   isTextBinaryFrame,
   isContinuationFrame
-} = __nccwpck_require__(4814)
-const { failWebsocketConnection } = __nccwpck_require__(9502)
-const { WebsocketFrameSend } = __nccwpck_require__(5949)
-const { PerMessageDeflate } = __nccwpck_require__(642)
-const { MessageSizeExceededError } = __nccwpck_require__(8450)
+} = __nccwpck_require__(4518)
+const { failWebsocketConnection } = __nccwpck_require__(6534)
+const { WebsocketFrameSend } = __nccwpck_require__(6373)
+const { PerMessageDeflate } = __nccwpck_require__(5738)
+const { MessageSizeExceededError } = __nccwpck_require__(9370)
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -46376,18 +46679,27 @@ class ByteParser extends Writable {
   /** @type {import('./websocket').Handler} */
   #handler
 
+  /** @type {number} */
+  #maxFragments
+
+  /** @type {number} */
+  #maxPayloadSize
+
   /**
    * @param {import('./websocket').Handler} handler
    * @param {Map<string, string>|null} extensions
+   * @param {{ maxFragments?: number, maxPayloadSize?: number }} [options]
    */
-  constructor (handler, extensions) {
+  constructor (handler, extensions, options = {}) {
     super()
 
     this.#handler = handler
     this.#extensions = extensions == null ? new Map() : extensions
+    this.#maxFragments = options.maxFragments ?? 0
+    this.#maxPayloadSize = options.maxPayloadSize ?? 0
 
     if (this.#extensions.has('permessage-deflate')) {
-      this.#extensions.set('permessage-deflate', new PerMessageDeflate(extensions))
+      this.#extensions.set('permessage-deflate', new PerMessageDeflate(extensions, options))
     }
   }
 
@@ -46401,6 +46713,19 @@ class ByteParser extends Writable {
     this.#loop = true
 
     this.run(callback)
+  }
+
+  #validatePayloadLength () {
+    if (
+      this.#maxPayloadSize > 0 &&
+      !isControlFrame(this.#info.opcode) &&
+      this.#info.payloadLength + this.#fragmentsBytes > this.#maxPayloadSize
+    ) {
+      failWebsocketConnection(this.#handler, 1009, 'Payload size exceeds maximum allowed size')
+      return false
+    }
+
+    return true
   }
 
   /**
@@ -46491,6 +46816,10 @@ class ByteParser extends Writable {
         if (payloadLength <= 125) {
           this.#info.payloadLength = payloadLength
           this.#state = parserStates.READ_DATA
+
+          if (!this.#validatePayloadLength()) {
+            return
+          }
         } else if (payloadLength === 126) {
           this.#state = parserStates.PAYLOADLENGTH_16
         } else if (payloadLength === 127) {
@@ -46515,6 +46844,10 @@ class ByteParser extends Writable {
 
         this.#info.payloadLength = buffer.readUInt16BE(0)
         this.#state = parserStates.READ_DATA
+
+        if (!this.#validatePayloadLength()) {
+          return
+        }
       } else if (this.#state === parserStates.PAYLOADLENGTH_64) {
         if (this.#byteOffset < 8) {
           return callback()
@@ -46537,6 +46870,10 @@ class ByteParser extends Writable {
 
         this.#info.payloadLength = lower
         this.#state = parserStates.READ_DATA
+
+        if (!this.#validatePayloadLength()) {
+          return
+        }
       } else if (this.#state === parserStates.READ_DATA) {
         if (this.#byteOffset < this.#info.payloadLength) {
           return callback()
@@ -46549,7 +46886,9 @@ class ByteParser extends Writable {
           this.#state = parserStates.INFO
         } else {
           if (!this.#info.compressed) {
-            this.writeFragments(body)
+            if (!this.writeFragments(body)) {
+              return
+            }
 
             // If the frame is not fragmented, a message has been received.
             // If the frame is fragmented, it will terminate with a fin bit set
@@ -46561,29 +46900,41 @@ class ByteParser extends Writable {
 
             this.#state = parserStates.INFO
           } else {
-            this.#extensions.get('permessage-deflate').decompress(body, this.#info.fin, (error, data) => {
-              if (error) {
-                // Use 1009 (Message Too Big) for decompression size limit errors
-                const code = error instanceof MessageSizeExceededError ? 1009 : 1007
-                failWebsocketConnection(this.#handler, code, error.message)
-                return
-              }
+            this.#extensions.get('permessage-deflate').decompress(
+              body,
+              this.#info.fin,
+              (error, data) => {
+                if (error) {
+                  const code = error instanceof MessageSizeExceededError ? 1009 : 1007
+                  failWebsocketConnection(this.#handler, code, error.message)
+                  return
+                }
 
-              this.writeFragments(data)
+                if (!this.writeFragments(data)) {
+                  return
+                }
 
-              if (!this.#info.fin) {
-                this.#state = parserStates.INFO
+                // Check cumulative fragment size
+                if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
+                  failWebsocketConnection(this.#handler, 1009, new MessageSizeExceededError().message)
+                  return
+                }
+
+                if (!this.#info.fin) {
+                  this.#state = parserStates.INFO
+                  this.#loop = true
+                  this.run(callback)
+                  return
+                }
+
+                websocketMessageReceived(this.#handler, this.#info.binaryType, this.consumeFragments())
+
                 this.#loop = true
+                this.#state = parserStates.INFO
                 this.run(callback)
-                return
-              }
-
-              websocketMessageReceived(this.#handler, this.#info.binaryType, this.consumeFragments())
-
-              this.#loop = true
-              this.#state = parserStates.INFO
-              this.run(callback)
-            })
+              },
+              this.#fragmentsBytes
+            )
 
             this.#loop = false
             break
@@ -46642,8 +46993,17 @@ class ByteParser extends Writable {
   }
 
   writeFragments (fragment) {
+    if (
+      this.#maxFragments > 0 &&
+      this.#fragments.length === this.#maxFragments
+    ) {
+      failWebsocketConnection(this.#handler, 1008, 'Too many message fragments')
+      return false
+    }
+
     this.#fragmentsBytes += fragment.length
     this.#fragments.push(fragment)
+    return true
   }
 
   consumeFragments () {
@@ -46789,14 +47149,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9623:
+/***/ 5775:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { WebsocketFrameSend } = __nccwpck_require__(5949)
-const { opcodes, sendHints } = __nccwpck_require__(865)
-const FixedQueue = __nccwpck_require__(6283)
+const { WebsocketFrameSend } = __nccwpck_require__(6373)
+const { opcodes, sendHints } = __nccwpck_require__(1769)
+const FixedQueue = __nccwpck_require__(2947)
 
 /**
  * @typedef {object} SendQueueNode
@@ -46905,15 +47265,15 @@ module.exports = { SendQueue }
 
 /***/ }),
 
-/***/ 3234:
+/***/ 1914:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { webidl } = __nccwpck_require__(8980)
-const { validateCloseCodeAndReason } = __nccwpck_require__(4814)
-const { kConstruct } = __nccwpck_require__(836)
-const { kEnumerableProperty } = __nccwpck_require__(9741)
+const { webidl } = __nccwpck_require__(28)
+const { validateCloseCodeAndReason } = __nccwpck_require__(4518)
+const { kConstruct } = __nccwpck_require__(3916)
+const { kEnumerableProperty } = __nccwpck_require__(6469)
 
 function createInheritableDOMException () {
   // https://github.com/nodejs/node/issues/59677
@@ -47016,23 +47376,23 @@ module.exports = { WebSocketError, createUnvalidatedWebSocketError }
 
 /***/ }),
 
-/***/ 3262:
+/***/ 9798:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { createDeferredPromise } = __nccwpck_require__(3191)
-const { environmentSettingsObject } = __nccwpck_require__(9691)
-const { states, opcodes, sentCloseFrameState } = __nccwpck_require__(865)
-const { webidl } = __nccwpck_require__(8980)
-const { getURLRecord, isValidSubprotocol, isEstablished, utf8Decode } = __nccwpck_require__(4814)
-const { establishWebSocketConnection, failWebsocketConnection, closeWebSocketConnection } = __nccwpck_require__(9502)
-const { channels } = __nccwpck_require__(1257)
-const { WebsocketFrameSend } = __nccwpck_require__(5949)
-const { ByteParser } = __nccwpck_require__(1611)
-const { WebSocketError, createUnvalidatedWebSocketError } = __nccwpck_require__(3234)
-const { kEnumerableProperty } = __nccwpck_require__(9741)
-const { utf8DecodeBytes } = __nccwpck_require__(311)
+const { createDeferredPromise } = __nccwpck_require__(3343)
+const { environmentSettingsObject } = __nccwpck_require__(2675)
+const { states, opcodes, sentCloseFrameState } = __nccwpck_require__(1769)
+const { webidl } = __nccwpck_require__(28)
+const { getURLRecord, isValidSubprotocol, isEstablished, utf8Decode } = __nccwpck_require__(4518)
+const { establishWebSocketConnection, failWebsocketConnection, closeWebSocketConnection } = __nccwpck_require__(6534)
+const { channels } = __nccwpck_require__(8369)
+const { WebsocketFrameSend } = __nccwpck_require__(6373)
+const { ByteParser } = __nccwpck_require__(6275)
+const { WebSocketError, createUnvalidatedWebSocketError } = __nccwpck_require__(1914)
+const { kEnumerableProperty } = __nccwpck_require__(6469)
+const { utf8DecodeBytes } = __nccwpck_require__(2783)
 
 let emittedExperimentalWarning = false
 
@@ -47279,7 +47639,14 @@ class WebSocketStream {
   #onConnectionEstablished (response, parsedExtensions) {
     this.#handler.socket = response.socket
 
-    const parser = new ByteParser(this.#handler, parsedExtensions)
+    // Get options from dispatcher options
+    const maxFragments = this.#handler.controller.dispatcher?.webSocketOptions?.maxFragments
+    const maxPayloadSize = this.#handler.controller.dispatcher?.webSocketOptions?.maxPayloadSize
+
+    const parser = new ByteParser(this.#handler, parsedExtensions, {
+      maxFragments,
+      maxPayloadSize
+    })
     parser.on('drain', () => this.#handler.onParserDrain())
     parser.on('error', (err) => this.#handler.onParserError(err))
 
@@ -47304,12 +47671,6 @@ class WebSocketStream {
     const readable = new ReadableStream({
       start: (controller) => {
         this.#readableStreamController = controller
-      },
-      pull (controller) {
-        let chunk
-        while (controller.desiredSize > 0 && (chunk = response.socket.read()) !== null) {
-          controller.enqueue(chunk)
-        }
       },
       cancel: (reason) => this.#cancel(reason)
     })
@@ -47359,7 +47720,7 @@ class WebSocketStream {
       try {
         chunk = utf8Decode(data)
       } catch {
-        failWebsocketConnection(this.#handler, 'Received invalid UTF-8 in text frame.')
+        failWebsocketConnection(this.#handler, 1007, 'Received invalid UTF-8 in text frame.')
         return
       }
     } else if (type === opcodes.BINARY) {
@@ -47520,15 +47881,15 @@ module.exports = { WebSocketStream }
 
 /***/ }),
 
-/***/ 4814:
+/***/ 4518:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
-const { states, opcodes } = __nccwpck_require__(865)
+const { states, opcodes } = __nccwpck_require__(1769)
 const { isUtf8 } = __nccwpck_require__(4573)
-const { removeHTTPWhitespace } = __nccwpck_require__(8847)
-const { collectASequenceOfCodePointsFast } = __nccwpck_require__(2465)
+const { removeHTTPWhitespace } = __nccwpck_require__(7127)
+const { collectASequenceOfCodePointsFast } = __nccwpck_require__(5001)
 
 /**
  * @param {number} readyState
@@ -47874,16 +48235,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6264:
+/***/ 1027:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
 
 const { isArrayBuffer } = __nccwpck_require__(3429)
-const { webidl } = __nccwpck_require__(8980)
-const { URLSerializer } = __nccwpck_require__(8847)
-const { environmentSettingsObject } = __nccwpck_require__(9691)
-const { staticPropertyDescriptors, states, sentCloseFrameState, sendHints, opcodes } = __nccwpck_require__(865)
+const { webidl } = __nccwpck_require__(28)
+const { URLSerializer } = __nccwpck_require__(7127)
+const { environmentSettingsObject } = __nccwpck_require__(2675)
+const { staticPropertyDescriptors, states, sentCloseFrameState, sendHints, opcodes } = __nccwpck_require__(1769)
 const {
   isConnecting,
   isEstablished,
@@ -47894,15 +48255,27 @@ const {
   utf8Decode,
   toArrayBuffer,
   getURLRecord
-} = __nccwpck_require__(4814)
-const { establishWebSocketConnection, closeWebSocketConnection, failWebsocketConnection } = __nccwpck_require__(9502)
-const { ByteParser } = __nccwpck_require__(1611)
-const { kEnumerableProperty } = __nccwpck_require__(9741)
-const { getGlobalDispatcher } = __nccwpck_require__(8598)
-const { ErrorEvent, CloseEvent, createFastMessageEvent } = __nccwpck_require__(7063)
-const { SendQueue } = __nccwpck_require__(9623)
-const { WebsocketFrameSend } = __nccwpck_require__(5949)
-const { channels } = __nccwpck_require__(1257)
+} = __nccwpck_require__(4518)
+const { establishWebSocketConnection, closeWebSocketConnection, failWebsocketConnection } = __nccwpck_require__(6534)
+const { ByteParser } = __nccwpck_require__(6275)
+const { kEnumerableProperty } = __nccwpck_require__(6469)
+const { getGlobalDispatcher } = __nccwpck_require__(6798)
+const { ErrorEvent, CloseEvent, createFastMessageEvent } = __nccwpck_require__(6943)
+const { SendQueue } = __nccwpck_require__(5775)
+const { WebsocketFrameSend } = __nccwpck_require__(6373)
+const { channels } = __nccwpck_require__(8369)
+
+function getSocketAddress (socket) {
+  if (typeof socket?.address === 'function') {
+    return socket.address()
+  }
+
+  if (typeof socket?.session?.socket?.address === 'function') {
+    return socket.session.socket.address()
+  }
+
+  return null
+}
 
 /**
  * @typedef {object} Handler
@@ -48335,7 +48708,14 @@ class WebSocket extends EventTarget {
     // once this happens, the connection is open
     this.#handler.socket = response.socket
 
-    const parser = new ByteParser(this.#handler, parsedExtensions)
+    const webSocketOptions = this.#handler.controller.dispatcher?.webSocketOptions
+    const maxFragments = webSocketOptions?.maxFragments
+    const maxPayloadSize = webSocketOptions?.maxPayloadSize
+
+    const parser = new ByteParser(this.#handler, parsedExtensions, {
+      maxFragments,
+      maxPayloadSize
+    })
     parser.on('drain', () => this.#handler.onParserDrain())
     parser.on('error', (err) => this.#handler.onParserError(err))
 
@@ -48370,7 +48750,7 @@ class WebSocket extends EventTarget {
       // Convert headers to a plain object for the event
       const headers = response.headersList.entries
       channels.open.publish({
-        address: response.socket.address(),
+        address: getSocketAddress(response.socket),
         protocol: this.#protocol,
         extensions: this.#extensions,
         websocket: this,
@@ -49370,8 +49750,8 @@ class DecodedURL extends URL {
 //# sourceMappingURL=proxy.js.map
 // EXTERNAL MODULE: ./node_modules/.pnpm/tunnel@0.0.6/node_modules/tunnel/index.js
 var node_modules_tunnel = __nccwpck_require__(1410);
-// EXTERNAL MODULE: ./node_modules/.pnpm/undici@7.24.4/node_modules/undici/index.js
-var undici = __nccwpck_require__(193);
+// EXTERNAL MODULE: ./node_modules/.pnpm/undici@7.28.0/node_modules/undici/index.js
+var undici = __nccwpck_require__(3241);
 ;// CONCATENATED MODULE: ./node_modules/.pnpm/@actions+http-client@4.0.0/node_modules/@actions/http-client/lib/index.js
 /* eslint-disable @typescript-eslint/no-explicit-any */
 var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@octokit/request-error@>=1.0.0 <5.1.1': '>=5.1.1'
   '@octokit/request@>=1.0.0 <8.4.1': '>=8.4.1'
   '@octokit/plugin-paginate-rest@>=1.0.0 <9.2.2': '>=9.2.2'
-  undici: ^7.24.4
+  undici: ^7.28.0
   fast-xml-parser: ^5.7.0
   vite: ^7.3.5
   lodash: ^4.18.1
@@ -2451,8 +2451,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.24.4:
-    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   universal-user-agent@6.0.1:
@@ -2691,7 +2691,7 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.2)
       '@octokit/request': 8.4.1
       '@octokit/request-error': 5.1.1
-      undici: 7.24.4
+      undici: 7.28.0
 
   '@actions/github@7.0.0':
     dependencies:
@@ -2701,7 +2701,7 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.2)
       '@octokit/request': 8.4.1
       '@octokit/request-error': 5.1.1
-      undici: 7.24.4
+      undici: 7.28.0
 
   '@actions/github@9.0.0':
     dependencies:
@@ -2711,7 +2711,7 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
       '@octokit/request': 10.0.8
       '@octokit/request-error': 7.1.0
-      undici: 7.24.4
+      undici: 7.28.0
 
   '@actions/glob@0.5.1':
     dependencies:
@@ -2721,17 +2721,17 @@ snapshots:
   '@actions/http-client@2.2.3':
     dependencies:
       tunnel: 0.0.6
-      undici: 7.24.4
+      undici: 7.28.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 7.24.4
+      undici: 7.28.0
 
   '@actions/http-client@4.0.0':
     dependencies:
       tunnel: 0.0.6
-      undici: 7.24.4
+      undici: 7.28.0
 
   '@actions/io@2.0.0': {}
 
@@ -5291,7 +5291,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.24.4: {}
+  undici@7.28.0: {}
 
   universal-user-agent@6.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ overrides:
   '@octokit/request@>=1.0.0 <8.4.1': '>=8.4.1'
   '@octokit/plugin-paginate-rest@>=1.0.0 <9.2.2': '>=9.2.2'
   # blanket pins to a secure major
-  'undici': '^7.24.4'
+  'undici': '^7.28.0'
   'fast-xml-parser': '^5.7.0'
   'vite': '^7.3.5'
   'lodash': '^4.18.1'


### PR DESCRIPTION
## Summary

- Raise the pnpm `undici` override from `^7.24.4` to `^7.28.0`.
- Regenerate `pnpm-lock.yaml` so all transitive `undici` users resolve to `7.28.0`.
- Rebuild `dist/index.js` with the updated dependency bundle.

## Why

Dependabot security update `1436222118` failed with `Dependabot cannot update to the required version` because `undici` is controlled through the repository pnpm override rather than a direct `package.json` dependency. The open alerts require `undici >= 7.28.0`.

## Validation

- `pnpm install --frozen-lockfile`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/ncc build src/index.ts`
- `./node_modules/.bin/eslint . --max-warnings 0 --no-warn-ignored`
- `./node_modules/.bin/prettier --check pnpm-workspace.yaml pnpm-lock.yaml`
- `env CI=true ./node_modules/.bin/vitest run`

Note: local `pnpm -s tsc --noEmit` hung in this shell, so the equivalent direct binary invocation was used for verification.