### PR TITLE
fix(deps): pin @types scope to public npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,14 @@
+# Pin the @types scope to the public npm registry.
+#
+# Background: Dependabot's pnpm resolution intermittently routes the @types
+# scope to GitHub Packages (https://npm.pkg.github.com), which only serves
+# GitHub's legacy DefinitelyTyped mirror (max @types/node 17.0.18). That makes
+# valid npmjs versions (e.g. @types/node@24.x) look unresolvable and breaks
+# Dependabot updates for any dependency that re-resolves @types/* — see the
+# failed `typescript` update.
+#
+# All other pnpm config lives in pnpm-workspace.yaml (pnpm 11 no longer reads
+# save-exact / engine-strict from .npmrc). This file intentionally carries ONLY
+# the scoped-registry mapping, which pnpm/Dependabot read exclusively from
+# .npmrc and cannot be expressed in pnpm-workspace.yaml.
+@types:registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary

Dependabot fails to update `typescript` (and any dependency that re-resolves `@types/*`) with:

```
[ERR_PNPM_NO_MATCHING_VERSION] No matching version found for @types/node@24.13.2
while fetching it from https://npm.pkg.github.com/
```

### Root cause

`@types/node@24.13.2` exists on npmjs.org — it's what we have pinned. The failure is a **registry-routing** problem: during Dependabot's pnpm resolve, the `@types` scope gets routed to **GitHub Packages** (`npm.pkg.github.com`), which only serves GitHub's *legacy DefinitelyTyped mirror* (dist-tags `ts2.0`…`ts4.7`, max `@types/node` `17.0.18`). A valid npmjs version then looks unresolvable.

It's scoped specifically to `@types`: other Dependabot PRs (`@actions/core`, `@commitlint/config-conventional`, `semver`) regenerate `pnpm-lock.yaml` fine from the public registry.

This is **not** configured in the repo or org:
- no `.npmrc`, no `registries:` block in `dependabot.yml` (and none in its history)
- `0` org-level and `0` repo-level Dependabot secrets — so no authenticated GitHub Packages registry could even be wired up

The routing originates inside Dependabot's own resolve environment. The only in-our-control lever is a repo-level override.

### Fix

Add a minimal `.npmrc` carrying **only** the `@types` scoped-registry mapping (`@types:registry=https://registry.npmjs.org/`). pnpm/Dependabot read scoped registries exclusively from `.npmrc`, so this can't live in `pnpm-workspace.yaml`; all other pnpm config stays there.

### Verification

- npmjs.org serves `@types/node@24.13.2` ✓
- After merge, re-run the npm ecosystem via **Insights → Dependency graph → Dependabot → Check for updates**; the `typescript` bump should resolve `@types/*` from npmjs and open normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)